### PR TITLE
feat: Add Python reference implementation (oamp-types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ All notable changes to this project will be documented in this file.
 - Protocol Buffer definitions
 - Rust reference implementation (oamp-types crate)
 - TypeScript reference implementation (@oamp/types package)
+- Python reference implementation (oamp-types package)
 - Validator CLI and test fixtures
 - Documentation: agent guide, backend guide, security guide

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Rust Crate](https://img.shields.io/crates/v/oamp-types.svg)](https://crates.io/crates/oamp-types)
 [![npm Package](https://img.shields.io/npm/v/@deepthinking/oamp-types.svg)](https://www.npmjs.com/package/@deepthinking/oamp-types)
+[![PyPI Package](https://img.shields.io/pypi/v/oamp-types.svg)](https://pypi.org/project/oamp-types/)
 
-[Specification](spec/v1/oamp-v1.md) | [Rust Crate](reference/rust/) | [TypeScript Package](reference/typescript/) | [Security Guide](docs/security-guide.md)
+[Specification](spec/v1/oamp-v1.md) | [Rust Crate](reference/rust/) | [TypeScript Package](reference/typescript/) | [Python Package](reference/python/) | [Security Guide](docs/security-guide.md)
 
 ---
 
@@ -147,6 +148,33 @@ console.log(entry.category);   // "correction"
 console.log(entry.confidence);  // 0.98
 ```
 
+### Python
+
+```bash
+pip install oamp-types
+```
+
+```python
+from oamp_types import (
+    KnowledgeEntry, KnowledgeCategory, KnowledgeSource,
+    validate_knowledge_entry,
+)
+
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="Never use unwrap() — use ? operator instead",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# Validate
+errors = validate_knowledge_entry(entry)
+
+# Serialize to JSON (exclude null optional fields)
+json_str = entry.model_dump_json(exclude_none=True)
+```
+
 ---
 
 ## Repository Structure
@@ -162,6 +190,7 @@ proto/oamp/v1/             Protocol Buffer definitions
 reference/
   rust/                    Rust crate: oamp-types
   typescript/              npm package: @oamp/types
+  python/                  PyPI package: oamp-types
 
 validators/
   validate.sh              CLI document validator
@@ -236,7 +265,8 @@ We welcome contributions:
 1. Read the [spec](spec/v1/oamp-v1.md) before proposing changes
 2. Add test fixtures for schema changes
 3. Update both Rust and TypeScript reference implementations
-4. Follow existing code style
+4. Include Python reference implementation alongside Rust and TypeScript
+5. Follow existing code style
 
 ---
 

--- a/reference/python/.gitignore
+++ b/reference/python/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*$py.class
+dist/
+build/
+*.egg-info/
+*.egg
+.pytest_cache/
+.venv/

--- a/reference/python/README.md
+++ b/reference/python/README.md
@@ -1,0 +1,161 @@
+# oamp-types
+
+Python types for the [Open Agent Memory Protocol (OAMP)](https://github.com/deep-thinking-llc/open-agent-memory-protocol) v1.0.0.
+
+Built on [Pydantic v2](https://docs.pydantic.dev/) for validation and serialization.
+
+## Install
+
+```bash
+pip install oamp-types
+```
+
+## Quick Start
+
+```python
+from oamp_types import (
+    KnowledgeEntry,
+    KnowledgeCategory,
+    KnowledgeSource,
+    KnowledgeStore,
+    UserModel,
+    CommunicationProfile,
+    ExpertiseDomain,
+    ExpertiseLevel,
+    Correction,
+    StatedPreference,
+    validate_knowledge_entry,
+    validate_knowledge_store,
+    validate_user_model,
+)
+
+# Create a knowledge entry
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="Never use unwrap() — use ? operator instead",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# Validate
+errors = validate_knowledge_entry(entry)
+assert len(errors) == 0
+
+# Serialize to JSON (exclude null optional fields for spec compliance)
+json_str = entry.model_dump_json(exclude_none=True)
+
+# Parse from dict or JSON
+parsed = KnowledgeEntry.model_validate_json(json_str)
+
+# Create a user model
+model = UserModel(user_id="user-123")
+model.communication = CommunicationProfile(
+    verbosity=-0.6,
+    formality=0.3,
+    prefers_examples=True,
+    prefers_explanations=False,
+    languages=["en", "de"],
+)
+model.expertise.append(
+    ExpertiseDomain(
+        domain="rust",
+        level=ExpertiseLevel.expert,
+        confidence=0.95,
+    )
+)
+
+# Bulk export
+store = KnowledgeStore(user_id="user-123", entries=[entry])
+```
+
+## Serialization
+
+Pydantic models support multiple serialization modes:
+
+```python
+# Exclude None values (matches Rust's skip_serializing_if = "Option::is_none")
+json_str = entry.model_dump_json(exclude_none=True)
+
+# Include all fields (useful for debugging)
+json_str = entry.model_dump_json()
+
+# Python dict output
+d = entry.model_dump(exclude_none=True)
+```
+
+**Note:** For spec-compliant output, use `exclude_none=True` to omit optional
+fields that are not set (e.g., `decay`, `agent_id`). This matches the behavior
+of the Rust and TypeScript reference implementations.
+
+## Validation
+
+Two levels of validation are provided:
+
+### Pydantic field validators (automatic)
+
+Creating or parsing models through Pydantic automatically validates:
+- Required fields must be present
+- `oamp_version` must be `"1.0.0"`
+- `type` must match the expected document type
+- `confidence` must be in [0.0, 1.0]
+- String fields must not be empty where required
+- Unknown fields are rejected (`extra = "forbid"`)
+- Ranges like `verbosity` (-1.0 to 1.0) and `formality` (-1.0 to 1.0)
+
+### Semantic validation functions (for data bypassing Pydantic)
+
+```python
+from oamp_types import validate_knowledge_entry, validate_knowledge_store, validate_user_model
+
+# Returns list of error strings; empty list means valid
+errors = validate_knowledge_entry(entry)
+if errors:
+    raise ValueError(f"Validation failed: {errors}")
+```
+
+These functions validate data that may have been constructed via
+`model_construct()` or loaded from untrusted sources where Pydantic's
+field validators were bypassed.
+
+## API
+
+### `KnowledgeEntry`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oamp_version` | `str` | ✅ | Defaults to `"1.0.0"` |
+| `type` | `str` | ✅ | Defaults to `"knowledge_entry"` |
+| `id` | `str` | ✅ | UUID v4, auto-generated |
+| `user_id` | `str` | ✅ | User identifier |
+| `category` | `KnowledgeCategory` | ✅ | `fact`, `preference`, `pattern`, `correction` |
+| `content` | `str` | ✅ | Natural language knowledge |
+| `confidence` | `float` | ✅ | 0.0–1.0 |
+| `source` | `KnowledgeSource` | ✅ | Provenance info |
+| `decay` | `KnowledgeDecay \| None` | ❌ | Temporal decay params |
+| `tags` | `list[str]` | ❌ | Free-form tags |
+| `metadata` | `dict[str, Any]` | ❌ | Vendor extensions |
+
+### `UserModel`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oamp_version` | `str` | ✅ | Defaults to `"1.0.0"` |
+| `type` | `str` | ✅ | Defaults to `"user_model"` |
+| `user_id` | `str` | ✅ | User identifier |
+| `model_version` | `int` | ✅ | ≥ 1, defaults to `1` |
+| `updated_at` | `datetime` | ✅ | Auto-set to now (UTC) |
+| `communication` | `CommunicationProfile \| None` | ❌ | Communication preferences |
+| `expertise` | `list[ExpertiseDomain]` | ❌ | Domain expertise |
+| `corrections` | `list[Correction]` | ❌ | Agent corrections |
+| `stated_preferences` | `list[StatedPreference]` | ❌ | Declared preferences |
+| `metadata` | `dict[str, Any]` | ❌ | Vendor extensions |
+
+## Python Version
+
+Requires Python ≥ 3.9. Uses `str, Enum` pattern for category/level enums
+(available since Python 3.11 as `StrEnum`, backported for 3.9 compatibility).
+
+## License
+
+MIT

--- a/reference/python/pyproject.toml
+++ b/reference/python/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "oamp-types"
+version = "1.0.0"
+description = "Open Agent Memory Protocol (OAMP) types for Python"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9"
+keywords = ["ai", "agent", "memory", "protocol", "oamp"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "pydantic>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/oamp_types"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/reference/python/src/oamp_types/__init__.py
+++ b/reference/python/src/oamp_types/__init__.py
@@ -1,0 +1,42 @@
+"""Open Agent Memory Protocol (OAMP) types for Python."""
+
+from .knowledge import (
+    KnowledgeCategory,
+    KnowledgeSource,
+    KnowledgeDecay,
+    KnowledgeEntry,
+    KnowledgeStore,
+)
+from .user_model import (
+    ExpertiseLevel,
+    CommunicationProfile,
+    ExpertiseDomain,
+    Correction,
+    StatedPreference,
+    UserModel,
+)
+from .validate import (
+    validate_knowledge_entry,
+    validate_knowledge_store,
+    validate_user_model,
+)
+
+OAMP_VERSION = "1.0.0"
+
+__all__ = [
+    "OAMP_VERSION",
+    "KnowledgeCategory",
+    "KnowledgeSource",
+    "KnowledgeDecay",
+    "KnowledgeEntry",
+    "KnowledgeStore",
+    "ExpertiseLevel",
+    "CommunicationProfile",
+    "ExpertiseDomain",
+    "Correction",
+    "StatedPreference",
+    "UserModel",
+    "validate_knowledge_entry",
+    "validate_knowledge_store",
+    "validate_user_model",
+]

--- a/reference/python/src/oamp_types/knowledge.py
+++ b/reference/python/src/oamp_types/knowledge.py
@@ -1,0 +1,142 @@
+"""Knowledge entry and store types for OAMP v1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class KnowledgeCategory(str, Enum):
+    """Category of a knowledge entry."""
+
+    fact = "fact"
+    preference = "preference"
+    pattern = "pattern"
+    correction = "correction"
+
+
+class KnowledgeSource(BaseModel):
+    """Provenance information for a knowledge entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    agent_id: Optional[str] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @field_validator("session_id")
+    @classmethod
+    def session_id_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("source.session_id must not be empty")
+        return v
+
+
+class KnowledgeDecay(BaseModel):
+    """Temporal decay parameters for confidence.
+
+    If half_life_days is None (or null), no decay is applied.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    half_life_days: Optional[float] = None
+    last_confirmed: Optional[datetime] = None
+
+    @field_validator("half_life_days")
+    @classmethod
+    def half_life_positive(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v <= 0:
+            raise ValueError("half_life_days must be positive")
+        return v
+
+
+class KnowledgeEntry(BaseModel):
+    """A discrete piece of information an agent has learned about a user."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    oamp_version: str = "1.0.0"
+    type: str = Field(default="knowledge_entry", alias="type")
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    user_id: str
+    category: KnowledgeCategory
+    content: str
+    confidence: float
+    source: KnowledgeSource
+    decay: Optional[KnowledgeDecay] = None
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("oamp_version")
+    @classmethod
+    def oamp_version_must_be_current(cls, v: str) -> str:
+        if v != "1.0.0":
+            raise ValueError(f"oamp_version must be '1.0.0', got '{v}'")
+        return v
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_knowledge_entry(cls, v: str) -> str:
+        if v != "knowledge_entry":
+            raise ValueError(f"type must be 'knowledge_entry', got '{v}'")
+        return v
+
+    @field_validator("user_id")
+    @classmethod
+    def user_id_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("user_id must not be empty")
+        return v
+
+    @field_validator("content")
+    @classmethod
+    def content_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("content must not be empty")
+        return v
+
+    @field_validator("confidence")
+    @classmethod
+    def confidence_in_range(cls, v: float) -> float:
+        if v < 0.0 or v > 1.0:
+            raise ValueError(f"confidence must be 0.0-1.0, got {v}")
+        return v
+
+
+class KnowledgeStore(BaseModel):
+    """A collection of knowledge entries for bulk export/import."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    oamp_version: str = "1.0.0"
+    type: str = Field(default="knowledge_store", alias="type")
+    user_id: str
+    entries: list[KnowledgeEntry] = Field(default_factory=list)
+    exported_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    agent_id: Optional[str] = None
+
+    @field_validator("oamp_version")
+    @classmethod
+    def oamp_version_must_be_current(cls, v: str) -> str:
+        if v != "1.0.0":
+            raise ValueError(f"oamp_version must be '1.0.0', got '{v}'")
+        return v
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_knowledge_store(cls, v: str) -> str:
+        if v != "knowledge_store":
+            raise ValueError(f"type must be 'knowledge_store', got '{v}'")
+        return v
+
+    @field_validator("user_id")
+    @classmethod
+    def user_id_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("user_id must not be empty")
+        return v

--- a/reference/python/src/oamp_types/user_model.py
+++ b/reference/python/src/oamp_types/user_model.py
@@ -1,0 +1,158 @@
+"""User model types for OAMP v1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ExpertiseLevel(str, Enum):
+    """Level of expertise in a domain."""
+
+    novice = "novice"
+    intermediate = "intermediate"
+    advanced = "advanced"
+    expert = "expert"
+
+
+class CommunicationProfile(BaseModel):
+    """How the user prefers to interact with agents."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    verbosity: float = 0.0
+    formality: float = 0.0
+    prefers_examples: bool = True
+    prefers_explanations: bool = True
+    languages: list[str] = Field(default_factory=lambda: ["en"])
+
+    @field_validator("verbosity")
+    @classmethod
+    def verbosity_in_range(cls, v: float) -> float:
+        if v < -1.0 or v > 1.0:
+            raise ValueError(f"verbosity must be -1.0 to 1.0, got {v}")
+        return v
+
+    @field_validator("formality")
+    @classmethod
+    def formality_in_range(cls, v: float) -> float:
+        if v < -1.0 or v > 1.0:
+            raise ValueError(f"formality must be -1.0 to 1.0, got {v}")
+        return v
+
+
+class ExpertiseDomain(BaseModel):
+    """The user's demonstrated knowledge in a domain."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    domain: str
+    level: ExpertiseLevel
+    confidence: float
+    evidence_sessions: list[str] = Field(default_factory=list)
+    last_observed: Optional[datetime] = None
+
+    @field_validator("domain")
+    @classmethod
+    def domain_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("domain must not be empty")
+        return v
+
+    @field_validator("confidence")
+    @classmethod
+    def confidence_in_range(cls, v: float) -> float:
+        if v < 0.0 or v > 1.0:
+            raise ValueError(f"confidence must be 0.0-1.0, got {v}")
+        return v
+
+
+class Correction(BaseModel):
+    """A record of the user correcting the agent's behavior."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    what_agent_did: str
+    what_user_wanted: str
+    context: Optional[str] = None
+    session_id: str
+    timestamp: datetime
+
+    @field_validator("what_agent_did")
+    @classmethod
+    def what_agent_did_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("what_agent_did must not be empty")
+        return v
+
+    @field_validator("what_user_wanted")
+    @classmethod
+    def what_user_wanted_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("what_user_wanted must not be empty")
+        return v
+
+    @field_validator("session_id")
+    @classmethod
+    def session_id_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("session_id must not be empty")
+        return v
+
+
+class StatedPreference(BaseModel):
+    """A preference the user has explicitly declared."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    value: str
+    timestamp: datetime
+
+    @field_validator("key")
+    @classmethod
+    def key_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("key must not be empty")
+        return v
+
+
+class UserModel(BaseModel):
+    """An agent's evolving structured understanding of a user."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    oamp_version: str = "1.0.0"
+    type: str = Field(default="user_model", alias="type")
+    user_id: str
+    model_version: int = Field(default=1, ge=1)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    communication: Optional[CommunicationProfile] = None
+    expertise: list[ExpertiseDomain] = Field(default_factory=list)
+    corrections: list[Correction] = Field(default_factory=list)
+    stated_preferences: list[StatedPreference] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("oamp_version")
+    @classmethod
+    def oamp_version_must_be_current(cls, v: str) -> str:
+        if v != "1.0.0":
+            raise ValueError(f"oamp_version must be '1.0.0', got '{v}'")
+        return v
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_user_model(cls, v: str) -> str:
+        if v != "user_model":
+            raise ValueError(f"type must be 'user_model', got '{v}'")
+        return v
+
+    @field_validator("user_id")
+    @classmethod
+    def user_id_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("user_id must not be empty")
+        return v

--- a/reference/python/src/oamp_types/validate.py
+++ b/reference/python/src/oamp_types/validate.py
@@ -1,0 +1,114 @@
+"""Validation functions for OAMP types.
+
+These functions perform semantic validation beyond what Pydantic
+field validators cover. They return a list of error strings;
+an empty list means the document is valid.
+
+This is useful for validating data that bypasses Pydantic's
+construction validation (e.g., data loaded via model_construct
+or imported from untrusted sources).
+"""
+
+from __future__ import annotations
+
+import re
+
+from .knowledge import KnowledgeEntry, KnowledgeStore
+from .user_model import UserModel
+
+# Loose UUID v4 pattern for validation
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def validate_knowledge_entry(entry: KnowledgeEntry) -> list[str]:
+    """Validate a KnowledgeEntry, returning a list of error strings."""
+    errors: list[str] = []
+
+    if not entry.oamp_version:
+        errors.append("oamp_version is required")
+    elif entry.oamp_version != "1.0.0":
+        errors.append(f"oamp_version must be '1.0.0', got '{entry.oamp_version}'")
+
+    if entry.type != "knowledge_entry":
+        errors.append(f"type must be 'knowledge_entry', got '{entry.type}'")
+
+    if not entry.id:
+        errors.append("id is required")
+    elif not _UUID_RE.match(entry.id):
+        errors.append(f"id must be a valid UUID v4, got '{entry.id}'")
+
+    if not entry.user_id:
+        errors.append("user_id is required")
+
+    if not entry.content:
+        errors.append("content is required")
+
+    if entry.confidence < 0.0 or entry.confidence > 1.0:
+        errors.append(f"confidence must be 0.0-1.0, got {entry.confidence}")
+
+    if not entry.source.session_id:
+        errors.append("source.session_id is required")
+
+    return errors
+
+
+def validate_knowledge_store(store: KnowledgeStore) -> list[str]:
+    """Validate a KnowledgeStore, returning a list of error strings."""
+    errors: list[str] = []
+
+    if not store.oamp_version:
+        errors.append("oamp_version is required")
+    elif store.oamp_version != "1.0.0":
+        errors.append(f"oamp_version must be '1.0.0', got '{store.oamp_version}'")
+
+    if store.type != "knowledge_store":
+        errors.append(f"type must be 'knowledge_store', got '{store.type}'")
+
+    if not store.user_id:
+        errors.append("user_id is required")
+
+    for i, entry in enumerate(store.entries):
+        entry_errors = validate_knowledge_entry(entry)
+        for err in entry_errors:
+            errors.append(f"entries[{i}]: {err}")
+
+    return errors
+
+
+def validate_user_model(model: UserModel) -> list[str]:
+    """Validate a UserModel, returning a list of error strings."""
+    errors: list[str] = []
+
+    if not model.oamp_version:
+        errors.append("oamp_version is required")
+    elif model.oamp_version != "1.0.0":
+        errors.append(f"oamp_version must be '1.0.0', got '{model.oamp_version}'")
+
+    if model.type != "user_model":
+        errors.append(f"type must be 'user_model', got '{model.type}'")
+
+    if not model.user_id:
+        errors.append("user_id is required")
+
+    if model.model_version < 1:
+        errors.append(f"model_version must be >= 1, got {model.model_version}")
+
+    # Validate communication ranges
+    if model.communication is not None:
+        comm = model.communication
+        if comm.verbosity < -1.0 or comm.verbosity > 1.0:
+            errors.append(f"verbosity must be -1.0 to 1.0, got {comm.verbosity}")
+        if comm.formality < -1.0 or comm.formality > 1.0:
+            errors.append(f"formality must be -1.0 to 1.0, got {comm.formality}")
+
+    # Validate expertise confidence
+    for i, exp in enumerate(model.expertise):
+        if exp.confidence < 0.0 or exp.confidence > 1.0:
+            errors.append(
+                f"expertise[{i}].confidence must be 0.0-1.0, got {exp.confidence}"
+            )
+
+    return errors

--- a/reference/python/tests/__init__.py
+++ b/reference/python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest configuration for OAMP types tests."""

--- a/reference/python/tests/test_oamp_types.py
+++ b/reference/python/tests/test_oamp_types.py
@@ -1,0 +1,610 @@
+"""Tests for OAMP Python types."""
+
+import json
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from oamp_types import (
+    KnowledgeCategory,
+    KnowledgeEntry,
+    KnowledgeSource,
+    KnowledgeDecay,
+    KnowledgeStore,
+    CommunicationProfile,
+    Correction,
+    ExpertiseDomain,
+    ExpertiseLevel,
+    OAMP_VERSION,
+    StatedPreference,
+    UserModel,
+    validate_knowledge_entry,
+    validate_knowledge_store,
+    validate_user_model,
+)
+
+SPEC_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "spec", "v1", "examples"
+)
+
+
+class TestKnowledgeEntry:
+    """Tests for KnowledgeEntry creation, serialization, and parsing."""
+
+    def test_create_knowledge_entry(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Knows Rust",
+            confidence=0.9,
+            source=KnowledgeSource(session_id="sess-1"),
+        )
+        assert entry.oamp_version == "1.0.0"
+        assert entry.type == "knowledge_entry"
+        assert entry.category == KnowledgeCategory.fact
+        assert entry.content == "Knows Rust"
+        assert entry.confidence == 0.9
+        assert entry.source.session_id == "sess-1"
+        assert entry.id  # auto-generated UUID
+
+    def test_knowledge_entry_roundtrip_json(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.correction,
+            content="Don't do X",
+            confidence=0.95,
+            source=KnowledgeSource(session_id="s2"),
+        )
+        json_str = entry.model_dump_json()
+        parsed = KnowledgeEntry.model_validate_json(json_str)
+        assert parsed.category == KnowledgeCategory.correction
+        assert parsed.content == "Don't do X"
+        assert parsed.confidence == 0.95
+
+    def test_knowledge_entry_with_decay(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.preference,
+            content="Prefers dark mode",
+            confidence=0.8,
+            source=KnowledgeSource(session_id="sess-1"),
+            decay=KnowledgeDecay(half_life_days=70.0),
+        )
+        assert entry.decay is not None
+        assert entry.decay.half_life_days == 70.0
+
+    def test_knowledge_entry_with_tags(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.pattern,
+            content="Deploys to staging before production",
+            confidence=0.75,
+            source=KnowledgeSource(session_id="sess-1"),
+            tags=["devops", "deployment"],
+        )
+        assert entry.tags == ["devops", "deployment"]
+
+    def test_knowledge_entry_with_all_optional_fields(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.correction,
+            content="Don't use unwrap()",
+            confidence=0.98,
+            source=KnowledgeSource(
+                session_id="sess-1",
+                agent_id="my-agent",
+                timestamp=datetime(2026, 3, 12, 16, 45, 0, tzinfo=timezone.utc),
+            ),
+            decay=KnowledgeDecay(
+                half_life_days=140.0,
+                last_confirmed=datetime(2026, 3, 28, 9, 15, 0, tzinfo=timezone.utc),
+            ),
+            tags=["rust", "code-style"],
+            metadata={"priority": "high"},
+        )
+        assert entry.source.agent_id == "my-agent"
+        assert entry.decay.last_confirmed is not None
+        assert entry.metadata == {"priority": "high"}
+
+    def test_reject_invalid_confidence(self):
+        with pytest.raises(ValidationError):
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.fact,
+                content="test",
+                confidence=1.5,
+                source=KnowledgeSource(session_id="s"),
+            )
+
+    def test_reject_confidence_below_zero(self):
+        with pytest.raises(ValidationError):
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.fact,
+                content="test",
+                confidence=-0.1,
+                source=KnowledgeSource(session_id="s"),
+            )
+
+    def test_reject_empty_content(self):
+        with pytest.raises(ValidationError):
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.fact,
+                content="",
+                confidence=0.5,
+                source=KnowledgeSource(session_id="s"),
+            )
+
+    def test_reject_empty_user_id(self):
+        with pytest.raises(ValidationError):
+            KnowledgeEntry(
+                user_id="",
+                category=KnowledgeCategory.fact,
+                content="test",
+                confidence=0.5,
+                source=KnowledgeSource(session_id="s"),
+            )
+
+    def test_reject_invalid_oamp_version(self):
+        with pytest.raises(ValidationError):
+            KnowledgeEntry(
+                user_id="user-1",
+                oamp_version="2.0.0",
+                category=KnowledgeCategory.fact,
+                content="test",
+                confidence=0.5,
+                source=KnowledgeSource(session_id="s"),
+            )
+
+    def test_reject_unknown_fields(self):
+        """extra='forbid' should reject unknown fields."""
+        with pytest.raises(ValidationError):
+            KnowledgeEntry.model_validate({
+                "oamp_version": "1.0.0",
+                "type": "knowledge_entry",
+                "id": str(uuid4()),
+                "user_id": "user-1",
+                "category": "fact",
+                "content": "test",
+                "confidence": 0.5,
+                "source": {"session_id": "s", "timestamp": "2026-01-01T00:00:00Z"},
+                "unknown_field": "should be rejected",
+            })
+
+    def test_parse_example_file(self):
+        path = os.path.join(SPEC_DIR, "knowledge-entry.json")
+        if not os.path.exists(path):
+            pytest.skip("Example file not found")
+        with open(path) as f:
+            data = json.load(f)
+        entry = KnowledgeEntry.model_validate(data)
+        assert entry.category == KnowledgeCategory.preference
+        assert entry.confidence > 0.0
+        assert entry.confidence <= 1.0
+
+
+class TestKnowledgeEntrySerialization:
+    """Tests for JSON serialization fidelity."""
+
+    def test_none_fields_omitted_in_json(self):
+        """Optional fields with None values should be omitted from JSON output."""
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Test",
+            confidence=0.9,
+            source=KnowledgeSource(session_id="s1"),
+        )
+        d = json.loads(entry.model_dump_json(exclude_none=True))
+        assert "decay" not in d
+        assert "agent_id" not in d.get("source", {})
+
+    def test_timestamp_includes_timezone(self):
+        """Timestamps should serialize with timezone info (Z suffix)."""
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Test",
+            confidence=0.9,
+            source=KnowledgeSource(session_id="s1"),
+        )
+        d = json.loads(entry.model_dump_json())
+        ts = d["source"]["timestamp"]
+        assert ts.endswith("Z"), f"Expected 'Z' suffix, got: {ts}"
+
+    def test_roundtrip_preserves_data(self):
+        """Round-trip serialization should preserve all data."""
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.preference,
+            content="Prefers dark mode",
+            confidence=0.8,
+            source=KnowledgeSource(
+                session_id="sess-1",
+                agent_id="my-agent",
+            ),
+            decay=KnowledgeDecay(half_life_days=70.0),
+            tags=["ui", "preference"],
+        )
+        json_str = entry.model_dump_json(exclude_none=True)
+        parsed = KnowledgeEntry.model_validate_json(json_str)
+        assert parsed.user_id == entry.user_id
+        assert parsed.category == entry.category
+        assert parsed.content == entry.content
+        assert parsed.confidence == entry.confidence
+        assert parsed.source.session_id == entry.source.session_id
+        assert parsed.source.agent_id == entry.source.agent_id
+        assert parsed.decay.half_life_days == entry.decay.half_life_days
+        assert parsed.tags == entry.tags
+
+
+class TestKnowledgeStore:
+    """Tests for KnowledgeStore creation and serialization."""
+
+    def test_create_knowledge_store(self):
+        entries = [
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.fact,
+                content="Fact 1",
+                confidence=0.8,
+                source=KnowledgeSource(session_id="s1"),
+            ),
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.correction,
+                content="Don't do X",
+                confidence=0.95,
+                source=KnowledgeSource(session_id="s2"),
+            ),
+        ]
+        store = KnowledgeStore(user_id="user-1", entries=entries)
+        assert store.oamp_version == "1.0.0"
+        assert store.type == "knowledge_store"
+        assert len(store.entries) == 2
+        assert store.user_id == "user-1"
+
+    def test_knowledge_store_roundtrip_json(self):
+        entries = [
+            KnowledgeEntry(
+                user_id="user-1",
+                category=KnowledgeCategory.fact,
+                content="Fact 1",
+                confidence=0.8,
+                source=KnowledgeSource(session_id="s1"),
+            ),
+        ]
+        store = KnowledgeStore(user_id="user-1", entries=entries)
+        json_str = store.model_dump_json()
+        parsed = KnowledgeStore.model_validate_json(json_str)
+        assert len(parsed.entries) == 1
+        assert parsed.user_id == "user-1"
+
+    def test_parse_example_file(self):
+        path = os.path.join(SPEC_DIR, "knowledge-store.json")
+        if not os.path.exists(path):
+            pytest.skip("Example file not found")
+        with open(path) as f:
+            data = json.load(f)
+        store = KnowledgeStore.model_validate(data)
+        assert store.type == "knowledge_store"
+
+    def test_store_entries_inherit_oamp_version(self):
+        """Entries in a store can omit oamp_version (it's inherited)."""
+        path = os.path.join(SPEC_DIR, "knowledge-store.json")
+        if not os.path.exists(path):
+            pytest.skip("Example file not found")
+        with open(path) as f:
+            data = json.load(f)
+        # Some entries may not have oamp_version — they inherit from store
+        for entry_data in data["entries"]:
+            entry_data.pop("oamp_version", None)
+            entry_data.pop("type", None)
+        # This should still parse if store provides defaults
+        # (KnowledgeEntry has defaults for oamp_version and type)
+
+
+class TestUserModel:
+    """Tests for UserModel creation, serialization, and parsing."""
+
+    def test_create_user_model(self):
+        model = UserModel(user_id="user-1")
+        assert model.oamp_version == "1.0.0"
+        assert model.type == "user_model"
+        assert model.user_id == "user-1"
+        assert model.model_version == 1
+
+    def test_user_model_with_communication(self):
+        model = UserModel(
+            user_id="user-1",
+            communication=CommunicationProfile(
+                verbosity=-0.5,
+                formality=0.3,
+                prefers_examples=True,
+                prefers_explanations=False,
+                languages=["en", "ja"],
+            ),
+        )
+        assert model.communication is not None
+        assert model.communication.verbosity == -0.5
+        assert model.communication.languages == ["en", "ja"]
+
+    def test_user_model_with_expertise(self):
+        model = UserModel(user_id="user-1")
+        model.expertise.append(
+            ExpertiseDomain(
+                domain="rust",
+                level=ExpertiseLevel.expert,
+                confidence=0.95,
+            )
+        )
+        assert len(model.expertise) == 1
+        assert model.expertise[0].level == ExpertiseLevel.expert
+
+    def test_user_model_with_corrections(self):
+        model = UserModel(user_id="user-1")
+        model.corrections.append(
+            Correction(
+                what_agent_did="Used unwrap()",
+                what_user_wanted="Use proper error handling",
+                session_id="sess-1",
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+        assert len(model.corrections) == 1
+
+    def test_user_model_with_stated_preferences(self):
+        model = UserModel(user_id="user-1")
+        model.stated_preferences.append(
+            StatedPreference(
+                key="code_style",
+                value="functional",
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+        assert len(model.stated_preferences) == 1
+
+    def test_user_model_roundtrip_json(self):
+        model = UserModel(
+            user_id="user-1",
+            communication=CommunicationProfile(
+                verbosity=-0.5,
+                formality=0.3,
+            ),
+        )
+        model.expertise.append(
+            ExpertiseDomain(
+                domain="rust",
+                level=ExpertiseLevel.expert,
+                confidence=0.95,
+            )
+        )
+        json_str = model.model_dump_json()
+        parsed = UserModel.model_validate_json(json_str)
+        assert parsed.expertise[0].level == ExpertiseLevel.expert
+        assert parsed.communication.verbosity == -0.5
+
+    def test_reject_verbosity_out_of_range(self):
+        with pytest.raises(ValidationError):
+            CommunicationProfile(verbosity=2.0, formality=0.0)
+
+    def test_reject_invalid_model_version(self):
+        with pytest.raises(ValidationError):
+            UserModel(user_id="user-1", model_version=0)
+
+    def test_reject_invalid_oamp_version(self):
+        with pytest.raises(ValidationError):
+            UserModel(user_id="user-1", oamp_version="2.0.0")
+
+    def test_reject_unknown_fields(self):
+        """extra='forbid' should reject unknown fields."""
+        with pytest.raises(ValidationError):
+            UserModel.model_validate({
+                "oamp_version": "1.0.0",
+                "type": "user_model",
+                "user_id": "user-1",
+                "model_version": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "unknown_field": "should be rejected",
+            })
+
+    def test_parse_example_file(self):
+        path = os.path.join(SPEC_DIR, "user-model.json")
+        if not os.path.exists(path):
+            pytest.skip("Example file not found")
+        with open(path) as f:
+            data = json.load(f)
+        model = UserModel.model_validate(data)
+        assert len(model.expertise) > 0
+        assert model.expertise[0].level == ExpertiseLevel.expert
+
+
+class TestUserModelSerialization:
+    """Tests for UserModel JSON serialization fidelity."""
+
+    def test_none_fields_omitted_in_json(self):
+        """Optional fields with None values should be omitted."""
+        model = UserModel(user_id="user-1")
+        d = json.loads(model.model_dump_json(exclude_none=True))
+        assert "communication" not in d
+        assert "agent_id" not in d  # UserModel doesn't have agent_id, but check pattern
+
+    def test_timestamp_includes_timezone(self):
+        """updated_at should have timezone info."""
+        model = UserModel(user_id="user-1")
+        d = json.loads(model.model_dump_json())
+        assert d["updated_at"].endswith("Z")
+
+
+class TestValidation:
+    """Tests for the validate_* functions."""
+
+    def test_validate_valid_knowledge_entry(self):
+        entry = KnowledgeEntry(
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Valid",
+            confidence=0.5,
+            source=KnowledgeSource(session_id="sess-1"),
+        )
+        errors = validate_knowledge_entry(entry)
+        assert len(errors) == 0
+
+    def test_validate_invalid_confidence(self):
+        """Validate catches out-of-range confidence even when Pydantic would reject it."""
+        entry = KnowledgeEntry.model_construct(
+            oamp_version="1.0.0",
+            type="knowledge_entry",
+            id=str(uuid4()),
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Test",
+            confidence=1.5,
+            source=KnowledgeSource(session_id="sess-1"),
+            decay=None,
+            tags=[],
+            metadata={},
+        )
+        errors = validate_knowledge_entry(entry)
+        assert len(errors) > 0
+        assert any("confidence" in e for e in errors)
+
+    def test_validate_empty_content(self):
+        """Validate catches empty content even when Pydantic would reject it."""
+        entry = KnowledgeEntry.model_construct(
+            oamp_version="1.0.0",
+            type="knowledge_entry",
+            id=str(uuid4()),
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="",
+            confidence=0.5,
+            source=KnowledgeSource(session_id="sess-1"),
+            decay=None,
+            tags=[],
+            metadata={},
+        )
+        errors = validate_knowledge_entry(entry)
+        assert len(errors) > 0
+        assert any("content" in e for e in errors)
+
+    def test_validate_invalid_oamp_version(self):
+        """Validate rejects wrong oamp_version."""
+        entry = KnowledgeEntry.model_construct(
+            oamp_version="2.0.0",
+            type="knowledge_entry",
+            id=str(uuid4()),
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Test",
+            confidence=0.5,
+            source=KnowledgeSource(session_id="sess-1"),
+            decay=None,
+            tags=[],
+            metadata={},
+        )
+        errors = validate_knowledge_entry(entry)
+        assert any("oamp_version" in e for e in errors)
+
+    def test_validate_invalid_uuid(self):
+        """Validate rejects non-UUID id."""
+        entry = KnowledgeEntry.model_construct(
+            oamp_version="1.0.0",
+            type="knowledge_entry",
+            id="not-a-uuid",
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Test",
+            confidence=0.5,
+            source=KnowledgeSource(session_id="sess-1"),
+            decay=None,
+            tags=[],
+            metadata={},
+        )
+        errors = validate_knowledge_entry(entry)
+        assert any("UUID" in e or "id" in e for e in errors)
+
+    def test_validate_valid_knowledge_store(self):
+        store = KnowledgeStore(user_id="user-1", entries=[])
+        errors = validate_knowledge_store(store)
+        assert len(errors) == 0
+
+    def test_validate_valid_user_model(self):
+        model = UserModel(user_id="user-1")
+        errors = validate_user_model(model)
+        assert len(errors) == 0
+
+    def test_validate_invalid_verbosity(self):
+        """Validate catches out-of-range verbosity."""
+        comm = CommunicationProfile.model_construct(
+            verbosity=2.0, formality=0.0,
+            prefers_examples=True, prefers_explanations=True, languages=["en"],
+        )
+        model = UserModel(
+            user_id="user-1",
+            communication=comm,
+        )
+        errors = validate_user_model(model)
+        assert len(errors) > 0
+        assert any("verbosity" in e for e in errors)
+
+    def test_validate_invalid_formality(self):
+        """Validate catches out-of-range formality."""
+        comm = CommunicationProfile.model_construct(
+            verbosity=0.0, formality=-1.5,
+            prefers_examples=True, prefers_explanations=True, languages=["en"],
+        )
+        model = UserModel(
+            user_id="user-1",
+            communication=comm,
+        )
+        errors = validate_user_model(model)
+        assert len(errors) > 0
+        assert any("formality" in e for e in errors)
+
+    def test_validate_expertise_confidence_out_of_range(self):
+        """Validate catches out-of-range expertise confidence."""
+        exp = ExpertiseDomain.model_construct(
+            domain="rust",
+            level=ExpertiseLevel.expert,
+            confidence=1.5,
+            evidence_sessions=[],
+            last_observed=None,
+        )
+        model = UserModel(user_id="user-1")
+        model.expertise.append(exp)
+        errors = validate_user_model(model)
+        assert len(errors) > 0
+        assert any("confidence" in e for e in errors)
+
+
+class TestCategoryEnum:
+    """Tests for KnowledgeCategory enum values."""
+
+    def test_category_values(self):
+        assert KnowledgeCategory.fact == "fact"
+        assert KnowledgeCategory.preference == "preference"
+        assert KnowledgeCategory.pattern == "pattern"
+        assert KnowledgeCategory.correction == "correction"
+
+    def test_category_from_string(self):
+        assert KnowledgeCategory("fact") == KnowledgeCategory.fact
+        assert KnowledgeCategory("correction") == KnowledgeCategory.correction
+
+
+class TestExpertiseLevelEnum:
+    """Tests for ExpertiseLevel enum values."""
+
+    def test_level_values(self):
+        assert ExpertiseLevel.novice == "novice"
+        assert ExpertiseLevel.intermediate == "intermediate"
+        assert ExpertiseLevel.advanced == "advanced"
+        assert ExpertiseLevel.expert == "expert"
+
+    def test_level_from_string(self):
+        assert ExpertiseLevel("expert") == ExpertiseLevel.expert
+        assert ExpertiseLevel("novice") == ExpertiseLevel.novice


### PR DESCRIPTION
## Summary

Adds a Python reference implementation (`oamp-types` PyPI package) for the Open Agent Memory Protocol v1.0.0, bringing feature parity with the existing Rust and TypeScript implementations.

## What's New

### `reference/python/` — Full Python Package

| File | Purpose |
|------|---------|
| `pyproject.toml` | Package config (`oamp-types`, Python ≥3.9, Pydantic v2) |
| `README.md` | Usage docs with API reference |
| `src/oamp_types/__init__.py` | Public API exports |
| `src/oamp_types/knowledge.py` | `KnowledgeCategory`, `KnowledgeSource`, `KnowledgeDecay`, `KnowledgeEntry`, `KnowledgeStore` |
| `src/oamp_types/user_model.py` | `ExpertiseLevel`, `CommunicationProfile`, `ExpertiseDomain`, `Correction`, `StatedPreference`, `UserModel` |
| `src/oamp_types/validate.py` | `validate_knowledge_entry()`, `validate_knowledge_store()`, `validate_user_model()` |
| `tests/test_oamp_types.py` | 46 tests |
| `.gitignore` | Python build artifacts |

### Key Design Decisions

- **Pydantic v2** for model definitions with field validators and `extra="forbid"` (matches JSON Schema `additionalProperties: false`)
- **`str, Enum`** pattern for category/level enums (Python 3.9+ compatible)
- **`datetime.now(timezone.utc)`** instead of deprecated `datetime.utcnow()` — produces spec-compliant ISO 8601 with `"Z"` suffix
- **`exclude_none=True`** serialization available for spec-compliant output (matches Rust's `skip_serializing_if="Option::is_none"`)
- **`oamp_version` const validation** — rejects versions other than `"1.0.0"`
- **UUID v4 auto-generation** for `KnowledgeEntry.id`
- **Semantic validate functions** for data that bypasses Pydantic construction (e.g., `model_construct()`)
- **46 comprehensive tests** — creation, round-trip JSON, spec example parsing, validation, enum values, error rejection, serialization fidelity, `extra="forbid"`, timestamp formatting

### Other Updates

- **README.md** — Added PyPI badge, Python Quick Start section, Python in repo structure, Python in contributing guidelines
- **CHANGELOG.md** — Added Python reference implementation entry

## Second-Pass Fixes (Spec Compliance)

During review, several issues were caught and fixed:

| Issue | Fix |
|-------|-----|
| Timestamps serialized without `"Z"` suffix | Changed `datetime.utcnow()` → `datetime.now(timezone.utc)` |
| Optional `None` fields included as `"field": null` | Documented `exclude_none=True` for spec-compliant output |
| Unknown fields silently accepted | Added `extra="forbid"` to all models |
| `oamp_version` not validated as const `"1.0.0"` | Added `oamp_version_must_be_current` field validator |
| UUID format not validated | Added UUID regex check in `validate_knowledge_entry()` |
| `StrEnum` not available in Python 3.9 | Used `str, Enum` pattern for 3.9+ compatibility |

## Test Results

```
Python:  46 passed ✅
Rust:    10 passed ✅  
TypeScript: 7 passed ✅
```

All spec example files parse and validate cleanly across all three implementations.