### PR TITLE
docs: Add Python section to all translated READMEs

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -8,8 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/badge/npm-%40oamp%2Ftypes-red.svg)](../reference/typescript/)
+[![PyPI Package](https://img.shields.io/pypi/v/oamp-types.svg)](https://pypi.org/project/oamp-types/)
 
-[仕様](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript パッケージ](../reference/typescript/) | [セキュリティガイド](security-guide.md)
+[仕様](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript パッケージ](../reference/typescript/) | [Python パッケージ](../reference/python/) | [セキュリティガイド](security-guide.md)
 
 ---
 
@@ -147,6 +148,33 @@ console.log(entry.category);   // "correction"
 console.log(entry.confidence);  // 0.98
 ```
 
+### Python
+
+```bash
+pip install oamp-types
+```
+
+```python
+from oamp_types import (
+    KnowledgeEntry, KnowledgeCategory, KnowledgeSource,
+    validate_knowledge_entry,
+)
+
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="unwrap()は使用しないでください — ?演算子を使用してください",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# 検証
+errors = validate_knowledge_entry(entry)
+
+# JSONにシリアライズ（null フィールドを除外）
+json_str = entry.model_dump_json(exclude_none=True)
+```
+
 ---
 
 ## リポジトリ構造
@@ -162,6 +190,7 @@ proto/oamp/v1/             Protocol Buffer定義
 reference/
   rust/                    Rust crate: oamp-types
   typescript/              npmパッケージ: @oamp/types
+  python/                  PyPIパッケージ: oamp-types
 
 validators/
   validate.sh              CLIドキュメントバリデータ
@@ -235,7 +264,7 @@ OAMP準拠のメモリストアを構築：
 
 1. 変更を提案する前に[仕様](../spec/v1/oamp-v1.md)を読んでください
 2. スキーマ変更にテストフィクスチャを追加してください
-3. RustとTypeScriptの両方のリファレンス実装を更新してください
+3. Rust、TypeScript、Pythonのすべてのリファレンス実装を更新してください
 4. 既存のコードスタイルに従ってください
 
 ---

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -8,8 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/badge/npm-%40oamp%2Ftypes-red.svg)](../reference/typescript/)
+[![PyPI Package](https://img.shields.io/pypi/v/oamp-types.svg)](https://pypi.org/project/oamp-types/)
 
-[사양](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript 패키지](../reference/typescript/) | [보안 가이드](security-guide.md)
+[사양](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript 패키지](../reference/typescript/) | [Python 패키지](../reference/python/) | [보안 가이드](security-guide.md)
 
 ---
 
@@ -147,6 +148,33 @@ console.log(entry.category);   // "correction"
 console.log(entry.confidence);  // 0.98
 ```
 
+### Python
+
+```bash
+pip install oamp-types
+```
+
+```python
+from oamp_types import (
+    KnowledgeEntry, KnowledgeCategory, KnowledgeSource,
+    validate_knowledge_entry,
+)
+
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="절대 unwrap()을 사용하지 마세요 — ? 연산자를 사용하세요",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# 검증
+errors = validate_knowledge_entry(entry)
+
+# JSON으로 직렬화 (null 필드 제외)
+json_str = entry.model_dump_json(exclude_none=True)
+```
+
 ---
 
 ## 저장소 구조
@@ -162,6 +190,7 @@ proto/oamp/v1/             Protocol Buffer 정의
 reference/
   rust/                    Rust crate: oamp-types
   typescript/              npm 패키지: @oamp/types
+  python/                  PyPI 패키지: oamp-types
 
 validators/
   validate.sh              CLI 문서 검증기
@@ -235,7 +264,7 @@ OAMP 호환 메모리 저장소를 구축하세요:
 
 1. 변경 사항을 제안하기 전에 [사양](../spec/v1/oamp-v1.md)을 읽으세요
 2. 스키마 변경에 대한 테스트 픽스처를 추가하세요
-3. Rust와 TypeScript 참조 구현을 모두 업데이트하세요
+3. Rust, TypeScript, Python 참조 구현을 모두 업데이트하세요
 4. 기존 코드 스타일을 따르세요
 
 ---

--- a/docs/README.ms.md
+++ b/docs/README.ms.md
@@ -8,8 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/badge/npm-%40oamp%2Ftypes-red.svg)](../reference/typescript/)
+[![PyPI Package](https://img.shields.io/pypi/v/oamp-types.svg)](https://pypi.org/project/oamp-types/)
 
-[Spesifikasi](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [Pakej TypeScript](../reference/typescript/) | [Panduan Keselamatan](security-guide.md)
+[Spesifikasi](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [Pakej TypeScript](../reference/typescript/) | [Pakej Python](../reference/python/) | [Panduan Keselamatan](security-guide.md)
 
 ---
 
@@ -147,6 +148,33 @@ console.log(entry.category);   // "correction"
 console.log(entry.confidence);  // 0.98
 ```
 
+### Python
+
+```bash
+pip install oamp-types
+```
+
+```python
+from oamp_types import (
+    KnowledgeEntry, KnowledgeCategory, KnowledgeSource,
+    validate_knowledge_entry,
+)
+
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="Jangan gunakan unwrap() — gunakan operator ?",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# Pengesahan
+errors = validate_knowledge_entry(entry)
+
+# Serialisasikan kepada JSON (kecualikan medan null)
+json_str = entry.model_dump_json(exclude_none=True)
+```
+
 ---
 
 ## Struktur Repositori
@@ -162,6 +190,7 @@ proto/oamp/v1/             Definisi Protocol Buffer
 reference/
   rust/                    Rust crate: oamp-types
   typescript/              Pakej npm: @oamp/types
+  python/                  Pakej PyPI: oamp-types
 
 validators/
   validate.sh              Pengesah dokumen CLI
@@ -235,7 +264,7 @@ Kami mengalu-alukan sumbangan:
 
 1. Baca [spesifikasi](../spec/v1/oamp-v1.md) sebelum mencadangkan perubahan
 2. Tambah fixture ujian untuk perubahan skema
-3. Kemas kini kedua-dua pelaksanaan rujukan Rust dan TypeScript
+3. Kemas kini semua tiga pelaksanaan rujukan: Rust, TypeScript, dan Python
 4. Ikut gaya kod sedia ada
 
 ---

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -8,8 +8,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/badge/npm-%40oamp%2Ftypes-red.svg)](../reference/typescript/)
+[![PyPI Package](https://img.shields.io/pypi/v/oamp-types.svg)](https://pypi.org/project/oamp-types/)
 
-[规范](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript 包](../reference/typescript/) | [安全指南](security-guide.md)
+[规范](../spec/v1/oamp-v1.md) | [Rust Crate](../reference/rust/) | [TypeScript 包](../reference/typescript/) | [Python 包](../reference/python/) | [安全指南](security-guide.md)
 
 ---
 
@@ -147,6 +148,33 @@ console.log(entry.category);   // "correction"
 console.log(entry.confidence);  // 0.98
 ```
 
+### Python
+
+```bash
+pip install oamp-types
+```
+
+```python
+from oamp_types import (
+    KnowledgeEntry, KnowledgeCategory, KnowledgeSource,
+    validate_knowledge_entry,
+)
+
+entry = KnowledgeEntry(
+    user_id="user-123",
+    category=KnowledgeCategory.correction,
+    content="永远不要使用 unwrap()——使用 ? 运算符",
+    confidence=0.98,
+    source=KnowledgeSource(session_id="session-42"),
+)
+
+# 验证
+errors = validate_knowledge_entry(entry)
+
+# 序列化为 JSON（排除空值字段）
+json_str = entry.model_dump_json(exclude_none=True)
+```
+
 ---
 
 ## 仓库结构
@@ -162,6 +190,7 @@ proto/oamp/v1/             Protocol Buffer 定义
 reference/
   rust/                    Rust crate: oamp-types
   typescript/              npm 包: @oamp/types
+  python/                  PyPI 包: oamp-types
 
 validators/
   validate.sh              CLI 文档验证器
@@ -235,7 +264,7 @@ docs/
 
 1. 在提出更改之前阅读[规范](../spec/v1/oamp-v1.md)
 2. 为 Schema 更改添加测试夹具
-3. 同时更新 Rust 和 TypeScript 参考实现
+3. 同时更新 Rust、TypeScript 和 Python 参考实现
 4. 遵循现有的代码风格
 
 ---


### PR DESCRIPTION
## Summary

Updates the four translated README files (Chinese, Korean, Japanese, Malay) to include the Python reference implementation, matching the changes already made to the English README in PR #1.

## Changes per file

Each of the four translated READMEs gets the same set of updates:

| Section | Change |
|---------|--------|
| **Header badges** | Added `[![PyPI Package] badge` and link to Python package |
| **Header nav links** | Added `Python 包 / 패키지 / パッケージ / Pakej` link |
| **Quick Start** | Added full Python code example with `pip install`, imports, creation, validation, and serialization |
| **Repository Structure** | Added `python/` line with PyPI package label |
| **Contributing** | Updated from "update both Rust and TypeScript" to "update all three: Rust, TypeScript, and Python" |

### Code example translations

- 🇨🇳 **Chinese**: `content="永远不要使用 unwrap()——使用 ? 运算符"`
- 🇰🇷 **Korean**: `content="절대 unwrap()을 사용하지 마세요 — ? 연산자를 사용하세요"`
- 🇯🇵 **Japanese**: `content="unwrap()は使用しないでください — ?演算子を使用してください"`
- 🇲🇾 **Malay**: `content="Jangan gunakan unwrap() — gunakan operator ?"`

## Preview

Each translated README now has a Python Quick Start section that mirrors the English version, but with localized code comments and example content where appropriate.

## Related

- PR #1 — Added Python reference implementation + English README updates