### PR TITLE
feat: add reference backend server (Phase 1+2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,40 @@ jobs:
         working-directory: reference/elixir
         run: mix test
 
+  # ── Reference Server ─────────────────────────────────
+
+  test-server:
+    name: Reference Server
+    runs-on: [self-hosted, macOS]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: server-${{ runner.os }}-${{ hashFiles('reference/server/pyproject.toml') }}
+          restore-keys: server-${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: reference/server
+        run: |-
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: reference/server
+        run: PYTHONPATH=src python3 -m pytest tests/ -v
+
   # ── Spec validation & cross-language checks ─────────────
 
   cross-language-check:
     name: Cross-language consistency
     runs-on: [self-hosted, macOS]
-    needs: [test-rust, test-typescript, test-python, test-go, test-elixir]
+    needs: [test-rust, test-typescript, test-python, test-go, test-elixir, test-server]
     timeout-minutes: 10
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Reference Backend Server** (`reference/server/`): FastAPI-based OAMP backend
+  - 12 REST endpoints: Knowledge CRUD, search, user model CRUD, bulk export/import
+  - SQLite persistence with `aiosqlite` async I/O
+  - FTS5 full-text search with Porter stemming
+  - Version conflict detection (monotonic `model_version`)
+  - Spec-compliant error responses (Section 6.8)
+  - Health check at `/health`
+  - OpenAPI/Swagger UI at `/docs`
+  - 59 tests covering CRUD, search, validation, bulk ops, spec round-trips
+  - Server README with architecture docs and quick start
+- CI workflow updated to include server test suite
+- README updated with server section and quick start
+
+## [1.0.1] - 2025-01-XX
+
+### Added
 - Initial v1.0.0 spec: KnowledgeEntry, KnowledgeStore, UserModel schemas
 - JSON Schema definitions (draft-2020-12)
 - Protocol Buffer definitions

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ errors = OampTypes.Validate.validate_knowledge_entry(entry)
 json = Entry.to_json(entry)
 ```
 
+### Reference Server
+
+```bash
+cd reference/server
+pip install -e ".[dev]"
+python -m oamp_server
+```
+
+OpenAPI docs at `http://localhost:8000/docs` — 12 endpoints for knowledge CRUD, user models, search, and bulk export/import.
+
 ---
 
 ```
@@ -240,6 +250,7 @@ reference/
   python/                  PyPI package: oamp-types
   go/                      Go module: oamp-go
   elixir/                  Hex package: oamp_types
+  server/                  FastAPI reference backend
 
 scripts/
   protoc-gen.sh            Generate code from protobuf definitions

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -191,6 +191,9 @@ reference/
   rust/                    Rust crate: oamp-types
   typescript/              npmパッケージ: @oamp/types
   python/                  PyPIパッケージ: oamp-types
+  go/                      Goモジュール: oamp-go
+  elixir/                  Hexパッケージ: oamp_types
+  server/                  FastAPIリファレンスバックエンド
 
 validators/
   validate.sh              CLIドキュメントバリデータ

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -191,6 +191,9 @@ reference/
   rust/                    Rust crate: oamp-types
   typescript/              npm 패키지: @oamp/types
   python/                  PyPI 패키지: oamp-types
+  go/                      Go 모듈: oamp-go
+  elixir/                  Hex 패키지: oamp_types
+  server/                  FastAPI 참조 백엔드
 
 validators/
   validate.sh              CLI 문서 검증기

--- a/docs/README.ms.md
+++ b/docs/README.ms.md
@@ -191,6 +191,9 @@ reference/
   rust/                    Rust crate: oamp-types
   typescript/              Pakej npm: @oamp/types
   python/                  Pakej PyPI: oamp-types
+  go/                      Modul Go: oamp-go
+  elixir/                  Pakej Hex: oamp_types
+  server/                  Backend rujukan FastAPI
 
 validators/
   validate.sh              Pengesah dokumen CLI

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -191,6 +191,9 @@ reference/
   rust/                    Rust crate: oamp-types
   typescript/              npm 包: @oamp/types
   python/                  PyPI 包: oamp-types
+  go/                      Go 模块: oamp-go
+  elixir/                  Hex 包: oamp_types
+  server/                  FastAPI 参考后端
 
 validators/
   validate.sh              CLI 文档验证器

--- a/reference/rust/Cargo.lock
+++ b/reference/rust/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "oamp-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "serde",

--- a/reference/server/README.md
+++ b/reference/server/README.md
@@ -1,0 +1,114 @@
+# OAMP Reference Backend Server
+
+FastAPI-based reference implementation of the Open Agent Memory Protocol backend API.
+
+## Features
+
+- **SQLite persistence** with async I/O via `aiosqlite`
+- **FTS5 full-text search** with Porter stemming for knowledge entry queries
+- **Version conflict detection** for User Model updates (monotonic `model_version`)
+- **Bulk export/import** via `KnowledgeStore` format
+- **OpenAPI/Swagger UI** auto-generated at `/docs`
+- **JSON error responses** per spec Section 6.8
+
+## Quick Start
+
+```bash
+# Install dependencies
+pip install -e ".[dev]"
+
+# Run the server
+python -m oamp_server
+
+# Or with custom settings
+python -m oamp_server --host 127.0.0.1 --port 8080 --db-path ./data/oamp.db
+
+# Run tests
+PYTHONPATH=src pytest tests/ -v
+```
+
+## API Endpoints
+
+### Knowledge Entries
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/v1/knowledge` | Create a KnowledgeEntry (201) |
+| `GET` | `/v1/knowledge?user_id=...` | List entries for a user |
+| `GET` | `/v1/knowledge/search?q=...&user_id=...` | Full-text search |
+| `GET` | `/v1/knowledge/{entry_id}` | Get entry by ID |
+| `PATCH` | `/v1/knowledge/{entry_id}` | Update confidence/tags/decay |
+| `DELETE` | `/v1/knowledge/{entry_id}` | Delete entry (204) |
+
+### User Models
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/v1/user-model` | Create (201) or update (200) model |
+| `GET` | `/v1/user-model/{user_id}` | Get model by user_id |
+| `DELETE` | `/v1/user-model/{user_id}` | Delete model + all knowledge (204) |
+
+### Bulk Operations
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/v1/export/{user_id}` | Export all knowledge as KnowledgeStore |
+| `POST` | `/v1/import` | Import a KnowledgeStore |
+
+### Health
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/health` | Health check |
+
+## Architecture
+
+```
+src/oamp_server/
+├── main.py              # FastAPI app factory, lifespan, error handlers
+├── config.py            # Settings (env vars: OAMP_DB_PATH, OAMP_HOST, OAMP_PORT)
+├── api/
+│   ├── knowledge.py      # Knowledge CRUD + search endpoints
+│   ├── user_model.py    # User model CRUD endpoints
+│   ├── bulk.py          # Export/import endpoints
+│   └── errors.py        # OampError, error response models
+├── services/
+│   ├── knowledge.py     # Knowledge business logic, validation
+│   └── user_model.py    # User model business logic, version enforcement
+├── repository/
+│   ├── base.py          # Abstract Repository interface
+│   └── sqlite.py        # SQLite + FTS5 implementation
+└── middleware/
+    └── __init__.py       # (future: auth, rate limiting)
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `OAMP_DB_PATH` | `oamp.db` | SQLite database path (use `:memory:` for tests) |
+| `OAMP_HOST` | `0.0.0.0` | Bind host |
+| `OAMP_PORT` | `8000` | Bind port |
+| `OAMP_LOG_LEVEL` | `info` | Log level |
+
+## Test Suite
+
+59 tests covering:
+
+- **CRUD operations**: Create, read, update, delete for knowledge entries and user models
+- **Search**: FTS5 full-text search with Porter stemming, case-insensitive, scoped to user
+- **Validation**: Error format (Section 6.8), forbidden PATCH fields, version conflicts
+- **Bulk**: Export/import round-trips, spec example validation
+- **Edge cases**: Empty stores, nonexistent resources, duplicate IDs
+
+Run with:
+```bash
+PYTHONPATH=src pytest tests/ -v
+```
+
+## Phase Status
+
+- [x] **Phase 1**: FastAPI skeleton, SQLite repo, Knowledge/UserModel CRUD
+- [x] **Phase 2**: FTS5 search, bulk export/import, PATCH endpoint
+- [ ] **Phase 3**: AES-256-GCM encryption at rest, key management
+- [ ] **Phase 4**: Docker, performance benchmarks, compliance test integration

--- a/reference/server/pyproject.toml
+++ b/reference/server/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "oamp-server"
+version = "1.0.1"
+description = "OAMP v1 reference backend server"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.29",
+    "oamp-types>=1.0.0",
+    "aiosqlite>=0.20",
+    "pydantic>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/reference/server/src/oamp_server/__init__.py
+++ b/reference/server/src/oamp_server/__init__.py
@@ -1,0 +1,6 @@
+"""OAMP Server package."""
+
+from .main import create_app
+from .config import Settings
+
+__all__ = ["create_app", "Settings"]

--- a/reference/server/src/oamp_server/__main__.py
+++ b/reference/server/src/oamp_server/__main__.py
@@ -1,0 +1,36 @@
+"""Run the OAMP reference server.
+
+Usage: python -m oamp_server [--host HOST] [--port PORT] [--db-path PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import uvicorn
+
+from .config import Settings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OAMP Reference Backend Server")
+    parser.add_argument("--host", default=None, help="Host to bind (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=None, help="Port to bind (default: 8000)")
+    parser.add_argument("--db-path", default=None, help="SQLite database path (default: oamp.db)")
+    args = parser.parse_args()
+
+    settings = Settings(
+        host=args.host or "0.0.0.0",
+        port=args.port or 8000,
+        db_path=args.db_path or "oamp.db",
+    )
+
+    uvicorn.run(
+        "oamp_server.main:create_app",
+        factory=True,
+        host=settings.host,
+        port=settings.port,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/server/src/oamp_server/api/__init__.py
+++ b/reference/server/src/oamp_server/api/__init__.py
@@ -1,0 +1,6 @@
+"""API package."""
+
+from .knowledge import router as knowledge_router
+from .user_model import router as user_model_router
+
+__all__ = ["knowledge_router", "user_model_router"]

--- a/reference/server/src/oamp_server/api/bulk.py
+++ b/reference/server/src/oamp_server/api/bulk.py
@@ -1,0 +1,47 @@
+"""Bulk export/import API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from oamp_types import KnowledgeStore
+
+from ..services.knowledge import KnowledgeService
+
+
+router = APIRouter(tags=["Bulk Operations"])
+
+
+def _get_service(request: Request) -> KnowledgeService:
+    return request.app.state.knowledge_service
+
+
+@router.get("/export/{user_id}")
+async def export_knowledge(
+    user_id: str,
+    service: KnowledgeService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Export all knowledge entries for a user as a KnowledgeStore.
+
+    Per spec Section 7.1: MUST support bulk export of all knowledge entries.
+    """
+    store = await service.export_user(user_id)
+    return store.model_dump(mode="json", exclude_none=True)
+
+
+@router.post("/import")
+async def import_knowledge(
+    store: KnowledgeStore,
+    service: KnowledgeService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Import a KnowledgeStore, creating all entries.
+
+    Per spec Section 7.2: MUST support bulk import of knowledge entries.
+    Returns count of entries imported.
+    """
+    count = await service.import_store(store)
+    return {
+        "imported": count,
+        "user_id": store.user_id,
+    }

--- a/reference/server/src/oamp_server/api/errors.py
+++ b/reference/server/src/oamp_server/api/errors.py
@@ -1,0 +1,42 @@
+"""Error response models for OAMP API."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response per OAMP spec Section 6.8."""
+
+    error: str
+    code: str
+
+
+class OampError(HTTPException):
+    """Base OAMP HTTP exception."""
+
+    def __init__(self, status_code: int, error: str, code: str) -> None:
+        self.error_msg = error
+        self.error_code = code
+        super().__init__(status_code=status_code, detail=ErrorResponse(error=error, code=code).model_dump())
+
+
+def not_found(resource_type: str, resource_id: str) -> OampError:
+    return OampError(404, f"{resource_type} not found: {resource_id}", "NOT_FOUND")
+
+
+def validation_error(msg: str) -> OampError:
+    return OampError(400, msg, "VALIDATION_ERROR")
+
+
+def version_conflict(stored_version: int, attempted_version: int) -> OampError:
+    return OampError(
+        409,
+        f"model_version {attempted_version} must be > {stored_version}",
+        "VERSION_CONFLICT",
+    )
+
+
+def forbidden_patch(field: str) -> OampError:
+    return OampError(400, f"Cannot patch field: {field}", "FORBIDDEN_PATCH")

--- a/reference/server/src/oamp_server/api/knowledge.py
+++ b/reference/server/src/oamp_server/api/knowledge.py
@@ -1,0 +1,91 @@
+"""Knowledge entry API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Request
+from oamp_types import KnowledgeEntry
+
+from ..services.knowledge import KnowledgeService
+
+
+router = APIRouter(tags=["Knowledge"])
+
+
+def _get_service(request: Request) -> KnowledgeService:
+    return request.app.state.knowledge_service
+
+
+@router.post("/knowledge", status_code=201)
+async def create_knowledge(
+    entry: KnowledgeEntry,
+    service: KnowledgeService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Store a new KnowledgeEntry."""
+    result = await service.create(entry)
+    return result.model_dump(mode="json", exclude_none=True)
+
+
+# ── Search must come before {entry_id} to avoid path parameter collision ──
+
+
+@router.get("/knowledge/search")
+async def search_knowledge(
+    q: str,
+    user_id: str,
+    category: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    service: KnowledgeService = Depends(_get_service),
+) -> list[dict[str, Any]]:
+    """Search knowledge entries by text query, scoped to a user."""
+    entries = await service.search(q, user_id, category, limit, offset)
+    return [e.model_dump(mode="json", exclude_none=True) for e in entries]
+
+
+@router.get("/knowledge")
+async def list_knowledge(
+    user_id: str,
+    category: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    service: KnowledgeService = Depends(_get_service),
+) -> list[dict[str, Any]]:
+    """List knowledge entries for a user, with optional category filter."""
+    entries = await service.list_entries(user_id, category, limit, offset)
+    return [e.model_dump(mode="json", exclude_none=True) for e in entries]
+
+
+@router.get("/knowledge/{entry_id}")
+async def get_knowledge(
+    entry_id: str,
+    service: KnowledgeService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Retrieve a KnowledgeEntry by ID."""
+    entry = await service.get(entry_id)
+    return entry.model_dump(mode="json", exclude_none=True)
+
+
+@router.delete("/knowledge/{entry_id}", status_code=204)
+async def delete_knowledge(
+    entry_id: str,
+    service: KnowledgeService = Depends(_get_service),
+) -> None:
+    """Delete a KnowledgeEntry."""
+    await service.delete(entry_id)
+
+
+@router.patch("/knowledge/{entry_id}")
+async def update_knowledge(
+    entry_id: str,
+    updates: dict[str, Any],
+    service: KnowledgeService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Update allowed fields on a KnowledgeEntry.
+
+    Per spec Section 6.2: only confidence, decay.last_confirmed, and tags
+    may be patched. Fields id, user_id, category, and source are forbidden.
+    """
+    entry = await service.update(entry_id, updates)
+    return entry.model_dump(mode="json", exclude_none=True)

--- a/reference/server/src/oamp_server/api/user_model.py
+++ b/reference/server/src/oamp_server/api/user_model.py
@@ -1,0 +1,53 @@
+"""User model API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request, Response
+from oamp_types import UserModel
+
+from ..services.user_model import UserModelService
+
+
+router = APIRouter(tags=["User Model"])
+
+
+def _get_service(request: Request) -> UserModelService:
+    return request.app.state.user_model_service
+
+
+@router.post("/user-model")
+async def create_or_update_user_model(
+    model: UserModel,
+    response: Response,
+    service: UserModelService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Store or update a UserModel.
+
+    Returns 201 for new models, 200 for updates.
+    Returns 409 if model_version <= stored version.
+    """
+    created, result = await service.create_or_update(model)
+    if created:
+        response.status_code = 201
+    return result.model_dump(mode="json", exclude_none=True)
+
+
+@router.get("/user-model/{user_id}")
+async def get_user_model(
+    user_id: str,
+    service: UserModelService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Retrieve a UserModel by user_id."""
+    model = await service.get(user_id)
+    return model.model_dump(mode="json", exclude_none=True)
+
+
+@router.delete("/user-model/{user_id}", status_code=204)
+async def delete_user_model(
+    user_id: str,
+    service: UserModelService = Depends(_get_service),
+) -> None:
+    """Delete a UserModel and all associated KnowledgeEntries."""
+    await service.delete(user_id)

--- a/reference/server/src/oamp_server/config.py
+++ b/reference/server/src/oamp_server/config.py
@@ -1,0 +1,28 @@
+"""OAMP v1 reference backend server configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Settings:
+    """Server configuration loaded from environment variables."""
+
+    db_path: str = field(
+        default_factory=lambda: os.environ.get(
+            "OAMP_DB_PATH", "oamp.db"
+        )
+    )
+    host: str = field(
+        default_factory=lambda: os.environ.get("OAMP_HOST", "0.0.0.0")
+    )
+    port: int = field(
+        default_factory=lambda: int(os.environ.get("OAMP_PORT", "8000"))
+    )
+    log_level: str = field(
+        default_factory=lambda: os.environ.get("OAMP_LOG_LEVEL", "info")
+    )
+    max_page_size: int = 200
+    default_page_size: int = 50

--- a/reference/server/src/oamp_server/main.py
+++ b/reference/server/src/oamp_server/main.py
@@ -1,0 +1,83 @@
+"""OAMP v1 reference backend server."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .api import bulk, knowledge, user_model
+from .api.errors import ErrorResponse, OampError
+from .config import Settings
+from .repository import SQLiteRepository
+from .services import KnowledgeService, UserModelService
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    settings = settings or Settings()
+
+    # ── Lifespan: initialize & tear down the repository ──
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Startup: initialize repository
+        repo = SQLiteRepository(db_path=settings.db_path)
+        await repo.initialize()
+        app.state.repo = repo
+        app.state.knowledge_service = KnowledgeService(repo)
+        app.state.user_model_service = UserModelService(repo)
+        yield
+        # Shutdown: close repository
+        await repo.close()
+
+    app = FastAPI(
+        title="Open Agent Memory Protocol API",
+        description=(
+            "OAMP defines a standard format for storing, exchanging, and querying "
+            "memory data between AI agents and memory backends."
+        ),
+        version="1.0.1",
+        lifespan=lifespan,
+    )
+
+    # Store settings on app state
+    app.state.settings = settings
+
+    # Register routers
+    app.include_router(knowledge.router, prefix="/v1")
+    app.include_router(user_model.router, prefix="/v1")
+    app.include_router(bulk.router, prefix="/v1")
+
+    # ── Error handlers ─────────────────────────────────
+
+    @app.exception_handler(OampError)
+    async def oamp_error_handler(request, exc: OampError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=ErrorResponse(error=exc.error_msg, code=exc.error_code).model_dump(),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(request, exc: RequestValidationError) -> JSONResponse:
+        errors = []
+        for err in exc.errors():
+            loc = ".".join(str(l) for l in err.get("loc", []))
+            errors.append(f"{loc}: {err.get('msg', 'invalid')}")
+        return JSONResponse(
+            status_code=400,
+            content=ErrorResponse(
+                error="; ".join(errors),
+                code="VALIDATION_ERROR",
+            ).model_dump(),
+        )
+
+    # ── Health check ───────────────────────────────────
+
+    @app.get("/health")
+    async def health_check() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app

--- a/reference/server/src/oamp_server/middleware/__init__.py
+++ b/reference/server/src/oamp_server/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Middleware package."""

--- a/reference/server/src/oamp_server/repository/__init__.py
+++ b/reference/server/src/oamp_server/repository/__init__.py
@@ -1,0 +1,6 @@
+"""Repository implementations for OAMP data persistence."""
+
+from .base import Repository
+from .sqlite import SQLiteRepository
+
+__all__ = ["Repository", "SQLiteRepository"]

--- a/reference/server/src/oamp_server/repository/base.py
+++ b/reference/server/src/oamp_server/repository/base.py
@@ -1,0 +1,86 @@
+"""Abstract repository interface for OAMP data persistence."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from oamp_types import KnowledgeEntry, KnowledgeStore, UserModel
+
+
+class Repository(ABC):
+    """Abstract base class for OAMP data persistence."""
+
+    # ── Knowledge Entries ─────────────────────────────
+
+    @abstractmethod
+    async def create_knowledge(self, entry: KnowledgeEntry) -> KnowledgeEntry:
+        """Store a new knowledge entry. Returns the stored entry."""
+        ...
+
+    @abstractmethod
+    async def get_knowledge(self, entry_id: str) -> KnowledgeEntry | None:
+        """Retrieve a knowledge entry by ID. Returns None if not found."""
+        ...
+
+    @abstractmethod
+    async def delete_knowledge(self, entry_id: str) -> bool:
+        """Delete a knowledge entry. Returns True if deleted, False if not found."""
+        ...
+
+    @abstractmethod
+    async def update_knowledge(
+        self, entry_id: str, updates: dict[str, Any]
+    ) -> KnowledgeEntry | None:
+        """Update specific fields on a knowledge entry. Returns updated entry or None."""
+        ...
+
+    @abstractmethod
+    async def list_knowledge(
+        self,
+        user_id: str,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[KnowledgeEntry]:
+        """List knowledge entries for a user, with optional category filter."""
+        ...
+
+    @abstractmethod
+    async def count_knowledge(self, user_id: str) -> int:
+        """Count knowledge entries for a user."""
+        ...
+
+    @abstractmethod
+    async def search_knowledge(
+        self,
+        query: str,
+        user_id: str,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[KnowledgeEntry]:
+        """Search knowledge entries by text content."""
+        ...
+
+    # ── User Models ───────────────────────────────────
+
+    @abstractmethod
+    async def create_user_model(self, model: UserModel) -> UserModel:
+        """Store a new user model. Returns the stored model."""
+        ...
+
+    @abstractmethod
+    async def get_user_model(self, user_id: str) -> UserModel | None:
+        """Retrieve a user model by user_id. Returns None if not found."""
+        ...
+
+    @abstractmethod
+    async def update_user_model(self, model: UserModel) -> UserModel:
+        """Update an existing user model. Returns the updated model."""
+        ...
+
+    @abstractmethod
+    async def delete_user_model(self, user_id: str) -> bool:
+        """Delete a user model and all associated knowledge entries."""
+        ...

--- a/reference/server/src/oamp_server/repository/sqlite.py
+++ b/reference/server/src/oamp_server/repository/sqlite.py
@@ -1,0 +1,423 @@
+"""SQLite repository implementation with FTS5 search.
+
+Phase 2: Real SQLite backend with async I/O, FTS5 full-text search,
+bulk export/import support, and proper SQL schema.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+import aiosqlite
+from oamp_types import KnowledgeEntry, KnowledgeStore, UserModel
+
+from .base import Repository
+
+SCHEMA = """
+-- Knowledge entries table
+CREATE TABLE IF NOT EXISTS knowledge_entries (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    content TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    source_json TEXT NOT NULL,
+    decay_json TEXT,
+    tags_json TEXT,
+    metadata_json TEXT,
+    oamp_version TEXT NOT NULL DEFAULT '1.0.0',
+    type TEXT NOT NULL DEFAULT 'knowledge_entry',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- User models table
+CREATE TABLE IF NOT EXISTS user_models (
+    user_id TEXT PRIMARY KEY,
+    model_version INTEGER NOT NULL,
+    oamp_version TEXT NOT NULL DEFAULT '1.0.0',
+    type TEXT NOT NULL DEFAULT 'user_model',
+    updated_at TEXT NOT NULL,
+    communication_json TEXT,
+    expertise_json TEXT,
+    corrections_json TEXT,
+    stated_preferences_json TEXT,
+    metadata_json TEXT,
+    created_at TEXT NOT NULL
+);
+
+-- FTS5 virtual table for knowledge content search (standalone, not content-sync)
+CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
+    entry_id,
+    user_id,
+    category,
+    content,
+    tokenize='porter'
+);
+
+-- Index for fast user_id lookups
+CREATE INDEX IF NOT EXISTS idx_knowledge_user_id ON knowledge_entries(user_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_user_category ON knowledge_entries(user_id, category);
+"""
+
+
+class SQLiteRepository(Repository):
+    """SQLite-backed OAMP repository with FTS5 search.
+
+    Uses aiosqlite for async I/O. Data is stored in a single .db file.
+    Optional in-memory mode for testing.
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._db_path = db_path
+        self._db: Optional[aiosqlite.Connection] = None
+
+    async def initialize(self) -> None:
+        """Open the database and create tables."""
+        self._db = await aiosqlite.connect(self._db_path)
+        self._db.row_factory = aiosqlite.Row
+        await self._db.executescript(SCHEMA)
+        await self._db.commit()
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._db:
+            await self._db.close()
+            self._db = None
+
+    def _ensure_connected(self) -> aiosqlite.Connection:
+        if self._db is None:
+            raise RuntimeError("Repository not initialized. Call initialize() first.")
+        return self._db
+
+    @staticmethod
+    def _now() -> str:
+        """Return current UTC timestamp as ISO format string."""
+        return datetime.now(timezone.utc).isoformat()
+
+    # ── Knowledge Entries ─────────────────────────────
+
+    async def create_knowledge(self, entry: KnowledgeEntry) -> KnowledgeEntry:
+        db = self._ensure_connected()
+        now = self._now()
+        category_val = entry.category.value if hasattr(entry.category, "value") else entry.category
+        source_json = json.dumps(entry.source.model_dump(mode="json", exclude_none=True)) if entry.source else "{}"
+        decay_json = json.dumps(entry.decay.model_dump(mode="json", exclude_none=True)) if entry.decay else None
+        tags_json = json.dumps(entry.tags) if entry.tags else None
+        metadata_json = json.dumps(entry.metadata) if entry.metadata else None
+
+        # Delete existing if replacing (to keep FTS in sync)
+        existing = await self.get_knowledge(entry.id)
+        if existing is not None:
+            await db.execute("DELETE FROM knowledge_entries WHERE id = ?", (entry.id,))
+
+        await db.execute(
+            """INSERT INTO knowledge_entries
+               (id, user_id, category, content, confidence, source_json,
+                decay_json, tags_json, metadata_json, oamp_version, type,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                entry.id, entry.user_id, category_val, entry.content,
+                entry.confidence, source_json, decay_json, tags_json,
+                metadata_json, entry.oamp_version, entry.type, now, now,
+            ),
+        )
+        # Insert into FTS index
+        await db.execute(
+            "INSERT INTO knowledge_fts (entry_id, user_id, category, content) VALUES (?, ?, ?, ?)",
+            (entry.id, entry.user_id, category_val, entry.content),
+        )
+        await db.commit()
+        return entry
+
+    async def get_knowledge(self, entry_id: str) -> Optional[KnowledgeEntry]:
+        db = self._ensure_connected()
+        async with db.execute(
+            "SELECT * FROM knowledge_entries WHERE id = ?", (entry_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_knowledge(row)
+
+    async def delete_knowledge(self, entry_id: str) -> bool:
+        db = self._ensure_connected()
+        # Delete from FTS first
+        await db.execute(
+            "DELETE FROM knowledge_fts WHERE entry_id = ?", (entry_id,)
+        )
+        cursor = await db.execute(
+            "DELETE FROM knowledge_entries WHERE id = ?", (entry_id,)
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+    async def update_knowledge(
+        self, entry_id: str, updates: dict[str, Any]
+    ) -> Optional[KnowledgeEntry]:
+        db = self._ensure_connected()
+        entry = await self.get_knowledge(entry_id)
+        if entry is None:
+            return None
+
+        set_clauses = []
+        values: list[Any] = []
+        fts_dirty = False
+
+        for field, value in updates.items():
+            if field == "confidence":
+                set_clauses.append("confidence = ?")
+                values.append(value)
+            elif field == "tags":
+                set_clauses.append("tags_json = ?")
+                values.append(json.dumps(value))
+            elif field == "decay":
+                set_clauses.append("decay_json = ?")
+                values.append(json.dumps(value) if value else None)
+            elif field == "metadata":
+                set_clauses.append("metadata_json = ?")
+                values.append(json.dumps(value) if value else None)
+            elif field == "content":
+                set_clauses.append("content = ?")
+                values.append(value)
+                fts_dirty = True
+            # Skip forbidden/unknown fields silently
+
+        if not set_clauses:
+            return entry
+
+        set_clauses.append("updated_at = ?")
+        values.append(self._now())
+        values.append(entry_id)
+
+        await db.execute(
+            f"UPDATE knowledge_entries SET {', '.join(set_clauses)} WHERE id = ?",
+            values,
+        )
+
+        # Update FTS if content changed
+        if fts_dirty:
+            # Get the new content value
+            new_content = updates.get("content", entry.content)
+            category_val = entry.category.value if hasattr(entry.category, "value") else entry.category
+            await db.execute(
+                "DELETE FROM knowledge_fts WHERE entry_id = ?", (entry_id,)
+            )
+            await db.execute(
+                "INSERT INTO knowledge_fts (entry_id, user_id, category, content) VALUES (?, ?, ?, ?)",
+                (entry_id, entry.user_id, category_val, new_content),
+            )
+
+        await db.commit()
+        return await self.get_knowledge(entry_id)
+
+    async def list_knowledge(
+        self,
+        user_id: str,
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[KnowledgeEntry]:
+        db = self._ensure_connected()
+        if category:
+            query = "SELECT * FROM knowledge_entries WHERE user_id = ? AND category = ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            params: tuple = (user_id, category, limit, offset)
+        else:
+            query = "SELECT * FROM knowledge_entries WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            params = (user_id, limit, offset)
+
+        results: list[KnowledgeEntry] = []
+        async with db.execute(query, params) as cursor:
+            async for row in cursor:
+                results.append(self._row_to_knowledge(row))
+        return results
+
+    async def count_knowledge(self, user_id: str) -> int:
+        db = self._ensure_connected()
+        async with db.execute(
+            "SELECT COUNT(*) FROM knowledge_entries WHERE user_id = ?", (user_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        return row[0]
+
+    async def search_knowledge(
+        self,
+        query: str,
+        user_id: str,
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[KnowledgeEntry]:
+        """FTS5-powered full-text search with Porter stemming.
+
+        Falls back to LIKE search if FTS5 is unavailable or query is malformed.
+        """
+        try:
+            return await self._fts5_search(query, user_id, category, limit, offset)
+        except Exception:
+            return await self._fallback_search(query, user_id, category, limit, offset)
+
+    async def _fts5_search(
+        self,
+        query: str,
+        user_id: str,
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[KnowledgeEntry]:
+        """Search using FTS5 MATCH with Porter stemming."""
+        db = self._ensure_connected()
+        # Escape special FTS5 characters for safety
+        safe_query = query.replace('"', '""')
+
+        if category:
+            sql = """
+                SELECT ke.* FROM knowledge_entries ke
+                INNER JOIN knowledge_fts kft ON kft.entry_id = ke.id
+                WHERE knowledge_fts MATCH ? AND kft.user_id = ? AND kft.category = ?
+                ORDER BY ke.created_at DESC
+                LIMIT ? OFFSET ?
+            """
+            params: tuple = (safe_query, user_id, category, limit, offset)
+        else:
+            sql = """
+                SELECT ke.* FROM knowledge_entries ke
+                INNER JOIN knowledge_fts kft ON kft.entry_id = ke.id
+                WHERE knowledge_fts MATCH ? AND kft.user_id = ?
+                ORDER BY ke.created_at DESC
+                LIMIT ? OFFSET ?
+            """
+            params = (safe_query, user_id, limit, offset)
+
+        results: list[KnowledgeEntry] = []
+        async with db.execute(sql, params) as cursor:
+            async for row in cursor:
+                results.append(self._row_to_knowledge(row))
+        return results
+
+    async def _fallback_search(
+        self,
+        query: str,
+        user_id: str,
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[KnowledgeEntry]:
+        """Fallback LIKE search when FTS5 fails."""
+        db = self._ensure_connected()
+        pattern = f"%{query}%"
+        if category:
+            sql = "SELECT * FROM knowledge_entries WHERE user_id = ? AND category = ? AND content LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            params: tuple = (user_id, category, pattern, limit, offset)
+        else:
+            sql = "SELECT * FROM knowledge_entries WHERE user_id = ? AND content LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            params = (user_id, pattern, limit, offset)
+
+        results: list[KnowledgeEntry] = []
+        async with db.execute(sql, params) as cursor:
+            async for row in cursor:
+                results.append(self._row_to_knowledge(row))
+        return results
+
+    # ── User Models ───────────────────────────────────
+
+    async def create_user_model(self, model: UserModel) -> UserModel:
+        db = self._ensure_connected()
+        now = self._now()
+        comm_json = json.dumps(model.communication.model_dump(mode="json", exclude_none=True)) if model.communication else None
+        exp_json = json.dumps([e.model_dump(mode="json", exclude_none=True) for e in model.expertise]) if model.expertise else None
+        corr_json = json.dumps([c.model_dump(mode="json", exclude_none=True) for c in model.corrections]) if model.corrections else None
+        pref_json = json.dumps([p.model_dump(mode="json", exclude_none=True) for p in model.stated_preferences]) if model.stated_preferences else None
+        meta_json = json.dumps(model.metadata) if model.metadata else None
+
+        await db.execute(
+            """INSERT OR REPLACE INTO user_models
+               (user_id, model_version, oamp_version, type, updated_at,
+                communication_json, expertise_json, corrections_json,
+                stated_preferences_json, metadata_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                model.user_id, model.model_version, model.oamp_version,
+                model.type, model.updated_at, comm_json, exp_json,
+                corr_json, pref_json, meta_json, now,
+            ),
+        )
+        await db.commit()
+        return model
+
+    async def get_user_model(self, user_id: str) -> Optional[UserModel]:
+        db = self._ensure_connected()
+        async with db.execute(
+            "SELECT * FROM user_models WHERE user_id = ?", (user_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_user_model(row)
+
+    async def update_user_model(self, model: UserModel) -> UserModel:
+        return await self.create_user_model(model)
+
+    async def delete_user_model(self, user_id: str) -> bool:
+        db = self._ensure_connected()
+        # Delete knowledge entries and FTS entries for this user
+        await db.execute(
+            "DELETE FROM knowledge_fts WHERE user_id = ?", (user_id,)
+        )
+        await db.execute(
+            "DELETE FROM knowledge_entries WHERE user_id = ?", (user_id,)
+        )
+        cursor = await db.execute(
+            "DELETE FROM user_models WHERE user_id = ?", (user_id,)
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+    # ── Conversions ───────────────────────────────────
+
+    @staticmethod
+    def _row_to_knowledge(row: aiosqlite.Row) -> KnowledgeEntry:
+        """Convert a database row to a KnowledgeEntry."""
+        data: dict[str, Any] = {
+            "id": row["id"],
+            "user_id": row["user_id"],
+            "category": row["category"],
+            "content": row["content"],
+            "confidence": row["confidence"],
+            "oamp_version": row["oamp_version"],
+            "type": row["type"],
+            "source": json.loads(row["source_json"]) if row["source_json"] else {},
+        }
+        if row["decay_json"]:
+            data["decay"] = json.loads(row["decay_json"])
+        if row["tags_json"]:
+            data["tags"] = json.loads(row["tags_json"])
+        if row["metadata_json"]:
+            data["metadata"] = json.loads(row["metadata_json"])
+        return KnowledgeEntry.model_validate(data)
+
+    @staticmethod
+    def _row_to_user_model(row: aiosqlite.Row) -> UserModel:
+        """Convert a database row to a UserModel."""
+        data: dict[str, Any] = {
+            "user_id": row["user_id"],
+            "model_version": row["model_version"],
+            "oamp_version": row["oamp_version"],
+            "type": row["type"],
+            "updated_at": row["updated_at"],
+        }
+        if row["communication_json"]:
+            data["communication"] = json.loads(row["communication_json"])
+        if row["expertise_json"]:
+            data["expertise"] = json.loads(row["expertise_json"])
+        if row["corrections_json"]:
+            data["corrections"] = json.loads(row["corrections_json"])
+        if row["stated_preferences_json"]:
+            data["stated_preferences"] = json.loads(row["stated_preferences_json"])
+        if row["metadata_json"]:
+            data["metadata"] = json.loads(row["metadata_json"])
+        return UserModel.model_validate(data)

--- a/reference/server/src/oamp_server/services/__init__.py
+++ b/reference/server/src/oamp_server/services/__init__.py
@@ -1,0 +1,6 @@
+"""Services package."""
+
+from .knowledge import KnowledgeService
+from .user_model import UserModelService
+
+__all__ = ["KnowledgeService", "UserModelService"]

--- a/reference/server/src/oamp_server/services/knowledge.py
+++ b/reference/server/src/oamp_server/services/knowledge.py
@@ -1,0 +1,110 @@
+"""Business logic for knowledge entry operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from oamp_types import KnowledgeEntry, KnowledgeStore, validate_knowledge_entry
+
+from ..api.errors import OampError, not_found, validation_error, forbidden_patch
+from ..repository.base import Repository
+
+
+class KnowledgeService:
+    """Service layer for knowledge entry operations."""
+
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+    async def create(self, entry: KnowledgeEntry) -> KnowledgeEntry:
+        """Create a new knowledge entry with validation."""
+        # Validate the entry
+        errors = validate_knowledge_entry(entry)
+        if errors:
+            raise validation_error("; ".join(errors))
+
+        # Store it
+        return await self.repo.create_knowledge(entry)
+
+    async def get(self, entry_id: str) -> KnowledgeEntry:
+        """Get a knowledge entry by ID."""
+        entry = await self.repo.get_knowledge(entry_id)
+        if entry is None:
+            raise not_found("KnowledgeEntry", entry_id)
+        return entry
+
+    async def delete(self, entry_id: str) -> None:
+        """Delete a knowledge entry."""
+        deleted = await self.repo.delete_knowledge(entry_id)
+        if not deleted:
+            raise not_found("KnowledgeEntry", entry_id)
+
+    async def update(self, entry_id: str, updates: dict[str, Any]) -> KnowledgeEntry:
+        """Update allowed fields on a knowledge entry.
+
+        Per spec Section 6.2, only these fields may be patched:
+        - confidence
+        - decay (specifically decay.last_confirmed)
+        - tags
+
+        Fields id, user_id, category, source are forbidden.
+        """
+        # Check for forbidden fields
+        forbidden = {"id", "user_id", "category", "source", "oamp_version", "type", "content"}
+        for field in updates:
+            if field in forbidden:
+                raise forbidden_patch(field)
+
+        entry = await self.repo.update_knowledge(entry_id, updates)
+        if entry is None:
+            raise not_found("KnowledgeEntry", entry_id)
+        return entry
+
+    async def list_entries(
+        self,
+        user_id: str,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[KnowledgeEntry]:
+        """List knowledge entries for a user."""
+        return await self.repo.list_knowledge(user_id, category, limit, offset)
+
+    async def search(
+        self,
+        query: str,
+        user_id: str,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[KnowledgeEntry]:
+        """Search knowledge entries by text query."""
+        return await self.repo.search_knowledge(query, user_id, category, limit, offset)
+
+    async def export_user(self, user_id: str) -> KnowledgeStore:
+        """Export all knowledge entries for a user as a KnowledgeStore."""
+        from datetime import datetime, timezone
+
+        entries = await self.repo.list_knowledge(user_id, limit=10000)
+        store = KnowledgeStore(
+            user_id=user_id,
+            entries=entries,
+            exported_at=datetime.now(timezone.utc),
+        )
+        return store
+
+    async def import_store(self, store: KnowledgeStore) -> int:
+        """Import a KnowledgeStore, creating all entries.
+
+        Returns the count of entries imported.
+        """
+        count = 0
+        for entry in store.entries:
+            # Validate each entry
+            errors = validate_knowledge_entry(entry)
+            if errors:
+                raise validation_error(f"Entry {entry.id}: {'; '.join(errors)}")
+
+            await self.repo.create_knowledge(entry)
+            count += 1
+        return count

--- a/reference/server/src/oamp_server/services/user_model.py
+++ b/reference/server/src/oamp_server/services/user_model.py
@@ -1,0 +1,57 @@
+"""Business logic for user model operations."""
+
+from __future__ import annotations
+
+from oamp_types import UserModel, validate_user_model
+
+from ..api.errors import not_found, validation_error, version_conflict
+from ..repository.base import Repository
+
+
+class UserModelService:
+    """Service layer for user model operations."""
+
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+    async def create_or_update(self, model: UserModel) -> tuple[bool, UserModel]:
+        """Create or update a user model with version enforcement.
+
+        Per spec Section 5.1, model_version must be monotonically increasing.
+
+        Returns (created, model) where created is True if this was a new model.
+        """
+        # Validate the model
+        errors = validate_user_model(model)
+        if errors:
+            raise validation_error("; ".join(errors))
+
+        existing = await self.repo.get_user_model(model.user_id)
+
+        if existing is None:
+            # New model
+            result = await self.repo.create_user_model(model)
+            return (True, result)
+        else:
+            # Update — enforce model_version monotonicity
+            if model.model_version <= existing.model_version:
+                raise version_conflict(existing.model_version, model.model_version)
+            result = await self.repo.update_user_model(model)
+            return (False, result)
+
+    async def get(self, user_id: str) -> UserModel:
+        """Get a user model by user_id."""
+        model = await self.repo.get_user_model(user_id)
+        if model is None:
+            raise not_found("UserModel", user_id)
+        return model
+
+    async def delete(self, user_id: str) -> None:
+        """Delete a user model and all associated knowledge entries.
+
+        Per spec Section 6.3: MUST delete the complete User Model and
+        all associated Knowledge Entries for the user.
+        """
+        deleted = await self.repo.delete_user_model(user_id)
+        if not deleted:
+            raise not_found("UserModel", user_id)

--- a/reference/server/tests/conftest.py
+++ b/reference/server/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared test fixtures for OAMP server tests."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from oamp_server import create_app, Settings
+
+
+@pytest.fixture
+def settings():
+    """Settings with in-memory SQLite for testing."""
+    return Settings(db_path=":memory:")
+
+
+@pytest_asyncio.fixture
+async def app(settings):
+    """Create a fresh FastAPI app and initialize the repository."""
+    app = create_app(settings)
+    # Manually trigger lifespan startup
+    async with app.router.lifespan_context(app):
+        yield app
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    """Create an async HTTP test client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def repo(app):
+    """Get the repository from the app state."""
+    return app.state.repo
+
+
+@pytest.fixture
+def make_knowledge_entry():
+    """Factory fixture to create knowledge entry dicts."""
+
+    def _make(
+        user_id: str = "user-test",
+        category: str = "fact",
+        content: str = "Test knowledge content",
+        confidence: float = 0.8,
+        session_id: str = "sess-test-001",
+    ) -> dict:
+        return {
+            "oamp_version": "1.0.0",
+            "type": "knowledge_entry",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "user_id": user_id,
+            "category": category,
+            "content": content,
+            "confidence": confidence,
+            "source": {
+                "session_id": session_id,
+                "timestamp": "2026-04-01T14:30:00Z",
+            },
+        }
+
+    return _make
+
+
+@pytest.fixture
+def make_user_model():
+    """Factory fixture to create user model dicts."""
+
+    def _make(
+        user_id: str = "user-test",
+        model_version: int = 1,
+    ) -> dict:
+        return {
+            "oamp_version": "1.0.0",
+            "type": "user_model",
+            "user_id": user_id,
+            "model_version": model_version,
+            "updated_at": "2026-04-28T12:00:00Z",
+        }
+
+    return _make

--- a/reference/server/tests/test_bulk.py
+++ b/reference/server/tests/test_bulk.py
@@ -1,0 +1,198 @@
+"""Tests for bulk export/import endpoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SPEC_EXAMPLES = Path(__file__).resolve().parents[3] / "spec" / "v1" / "examples"
+
+
+class TestExportKnowledge:
+    """GET /v1/export/:user_id"""
+
+    async def test_export_empty_user(self, client):
+        """Export for user with no entries returns empty store."""
+        resp = await client.get("/v1/export/user-nonexistent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "user-nonexistent"
+        assert data["entries"] == []
+        assert data["type"] == "knowledge_store"
+
+    async def test_export_after_create(self, client, make_knowledge_entry):
+        """Export after creating entries returns them."""
+        uuids = [
+            "a0000001-e29b-41d4-a716-446655440001",
+            "a0000002-e29b-41d4-a716-446655440002",
+        ]
+        for i in range(2):
+            entry = make_knowledge_entry(user_id="user-export")
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        resp = await client.get("/v1/export/user-export")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "user-export"
+        assert len(data["entries"]) == 2
+        assert data["type"] == "knowledge_store"
+        assert data["oamp_version"] == "1.0.0"
+        assert "exported_at" in data
+
+    async def test_export_only_includes_user_entries(self, client, make_knowledge_entry):
+        """Export should only include entries for the specified user."""
+        # Create entries for two different users
+        entry_a = make_knowledge_entry(user_id="user-export-a")
+        entry_a["id"] = "b0000001-e29b-41d4-a716-446655440001"
+        await client.post("/v1/knowledge", json=entry_a)
+
+        entry_b = make_knowledge_entry(user_id="user-export-b")
+        entry_b["id"] = "b0000002-e29b-41d4-a716-446655440002"
+        await client.post("/v1/knowledge", json=entry_b)
+
+        # Export user-a should only contain user-a's entry
+        resp = await client.get("/v1/export/user-export-a")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["user_id"] == "user-export-a"
+
+
+class TestImportKnowledge:
+    """POST /v1/import"""
+
+    async def test_import_valid_store(self, client, make_knowledge_entry):
+        """Import a KnowledgeStore and verify entries are created."""
+        # Build a store with 3 entries
+        entries = []
+        uuids = [
+            "c0000001-e29b-41d4-a716-446655440001",
+            "c0000002-e29b-41d4-a716-446655440002",
+            "c0000003-e29b-41d4-a716-446655440003",
+        ]
+        for i in range(3):
+            entry = make_knowledge_entry(
+                user_id="user-import",
+                category=["fact", "preference", "correction"][i],
+                content=f"Imported entry {i + 1}",
+            )
+            entry["id"] = uuids[i]
+            entries.append(entry)
+
+        store = {
+            "oamp_version": "1.0.0",
+            "type": "knowledge_store",
+            "user_id": "user-import",
+            "entries": entries,
+        }
+
+        resp = await client.post("/v1/import", json=store)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["imported"] == 3
+        assert data["user_id"] == "user-import"
+
+        # Verify entries are retrievable
+        resp = await client.get("/v1/knowledge", params={"user_id": "user-import"})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+    async def test_import_empty_store(self, client):
+        """Import an empty store returns 0."""
+        store = {
+            "oamp_version": "1.0.0",
+            "type": "knowledge_store",
+            "user_id": "user-import-empty",
+            "entries": [],
+        }
+        resp = await client.post("/v1/import", json=store)
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 0
+
+    async def test_import_invalid_entry_in_store(self, client):
+        """Import with invalid entry returns validation error."""
+        store = {
+            "oamp_version": "1.0.0",
+            "type": "knowledge_store",
+            "user_id": "user-import-err",
+            "entries": [
+                {
+                    "oamp_version": "1.0.0",
+                    "type": "knowledge_entry",
+                    "id": "d0000001-e29b-41d4-a716-446655440001",
+                    "user_id": "user-import-err",
+                    "category": "fact",
+                    "content": "Valid entry",
+                    "confidence": 0.8,
+                    "source": {"session_id": "s1", "timestamp": "2026-04-01T14:30:00Z"},
+                },
+                {
+                    "oamp_version": "1.0.0",
+                    "type": "knowledge_entry",
+                    "id": "d0000002-e29b-41d4-a716-446655440002",
+                    "user_id": "user-import-err",
+                    "category": "invalid_category",  # Invalid!
+                    "content": "Bad entry",
+                    "confidence": 0.8,
+                    "source": {"session_id": "s2", "timestamp": "2026-04-01T14:30:00Z"},
+                },
+            ],
+        }
+        resp = await client.post("/v1/import", json=store)
+        assert resp.status_code == 400
+
+    async def test_import_then_export_roundtrip(self, client, make_knowledge_entry):
+        """Import a store, then export should return the same entries."""
+        entries = []
+        uuids = [
+            "e0000001-e29b-41d4-a716-446655440001",
+            "e0000002-e29b-41d4-a716-446655440002",
+        ]
+        for i in range(2):
+            entry = make_knowledge_entry(
+                user_id="user-rt",
+                content=f"Round-trip entry {i + 1}",
+            )
+            entry["id"] = uuids[i]
+            entries.append(entry)
+
+        store = {
+            "oamp_version": "1.0.0",
+            "type": "knowledge_store",
+            "user_id": "user-rt",
+            "entries": entries,
+        }
+
+        # Import
+        resp = await client.post("/v1/import", json=store)
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 2
+
+        # Export
+        resp = await client.get("/v1/export/user-rt")
+        assert resp.status_code == 200
+        exported = resp.json()
+        assert len(exported["entries"]) == 2
+        exported_ids = {e["id"] for e in exported["entries"]}
+        assert exported_ids == {uuids[0], uuids[1]}
+
+    async def test_import_spec_knowledge_store_example(self, client):
+        """Import the spec example knowledge-store.json."""
+        path = SPEC_EXAMPLES / "knowledge-store.json"
+        if not path.exists():
+            pytest.skip("spec example not found")
+
+        store = json.loads(path.read_text())
+
+        resp = await client.post("/v1/import", json=store)
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 3
+
+        # Verify via list
+        resp = await client.get("/v1/knowledge", params={"user_id": store["user_id"]})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3

--- a/reference/server/tests/test_health_and_roundtrip.py
+++ b/reference/server/tests/test_health_and_roundtrip.py
@@ -1,0 +1,100 @@
+"""Tests for health check and spec example round-trips."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SPEC_EXAMPLES = Path(__file__).resolve().parents[3] / "spec" / "v1" / "examples"
+
+
+class TestHealthCheck:
+    """GET /health"""
+
+    async def test_health_check(self, client):
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+
+
+class TestSpecExampleRoundTrips:
+    """Verify that spec examples can be stored and retrieved via the API."""
+
+    async def test_knowledge_entry_spec_example(self, client):
+        """POST then GET the spec example knowledge-entry.json."""
+        path = SPEC_EXAMPLES / "knowledge-entry.json"
+        if not path.exists():
+            pytest.skip("spec example not found")
+
+        entry = json.loads(path.read_text())
+
+        # POST
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201, f"Create failed: {resp.json()}"
+
+        # GET
+        resp = await client.get(f"/v1/knowledge/{entry['id']}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Verify round-trip (key fields)
+        assert data["id"] == entry["id"]
+        assert data["user_id"] == entry["user_id"]
+        assert data["category"] == entry["category"]
+        assert data["content"] == entry["content"]
+        assert data["confidence"] == entry["confidence"]
+        assert data["tags"] == entry["tags"]
+
+    async def test_user_model_spec_example(self, client):
+        """POST then GET the spec example user-model.json."""
+        path = SPEC_EXAMPLES / "user-model.json"
+        if not path.exists():
+            pytest.skip("spec example not found")
+
+        model = json.loads(path.read_text())
+
+        # POST
+        resp = await client.post("/v1/user-model", json=model)
+        assert resp.status_code == 201, f"Create failed: {resp.json()}"
+
+        # GET
+        resp = await client.get(f"/v1/user-model/{model['user_id']}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Verify round-trip (key fields)
+        assert data["user_id"] == model["user_id"]
+        assert data["model_version"] == model["model_version"]
+        assert len(data["expertise"]) == 3
+        assert data["communication"]["verbosity"] == -0.6
+
+    async def test_knowledge_store_spec_example_import(self, client):
+        """POST entries from knowledge-store.json, then list them."""
+        path = SPEC_EXAMPLES / "knowledge-store.json"
+        if not path.exists():
+            pytest.skip("spec example not found")
+
+        store = json.loads(path.read_text())
+        user_id = store["user_id"]
+
+        # POST each entry
+        for entry in store["entries"]:
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201, f"Create failed for {entry['id']}: {resp.json()}"
+
+        # LIST and verify count
+        resp = await client.get("/v1/knowledge", params={"user_id": user_id})
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 3
+
+        # SEARCH for "Rust" — should find entry about unwrap
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "unwrap", "user_id": user_id},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1

--- a/reference/server/tests/test_knowledge_crud.py
+++ b/reference/server/tests/test_knowledge_crud.py
@@ -1,0 +1,189 @@
+"""Tests for knowledge entry CRUD endpoints."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestCreateKnowledge:
+    """POST /v1/knowledge"""
+
+    async def test_create_valid_entry(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["id"] == entry["id"]
+        assert data["user_id"] == entry["user_id"]
+        assert data["category"] == entry["category"]
+        assert data["content"] == entry["content"]
+        assert data["confidence"] == entry["confidence"]
+
+    async def test_create_with_optional_fields(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        entry["decay"] = {"half_life_days": 70.0, "last_confirmed": "2026-04-01T14:30:00Z"}
+        entry["tags"] = ["test", "automated"]
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["decay"]["half_life_days"] == 70.0
+        assert data["tags"] == ["test", "automated"]
+
+    async def test_create_with_unknown_metadata(self, client, make_knowledge_entry):
+        """Spec Section 9: MUST NOT reject documents with unknown metadata fields."""
+        entry = make_knowledge_entry()
+        entry["metadata"] = {"custom_key": "custom_value", "vendor_ext": 42}
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+    async def test_create_invalid_confidence(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(confidence=1.5)
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+
+    async def test_create_empty_content(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(content="")
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+
+    async def test_create_invalid_category(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(category="unknown")
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+
+    async def test_create_missing_source(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        del entry["source"]
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+
+    async def test_create_invalid_oamp_version(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        entry["oamp_version"] = "2.0.0"
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+
+
+class TestGetKnowledge:
+    """GET /v1/knowledge/:id"""
+
+    async def test_get_existing_entry(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+        resp = await client.get(f"/v1/knowledge/{entry['id']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == entry["id"]
+
+    async def test_get_nonexistent_entry(self, client):
+        resp = await client.get("/v1/knowledge/ nonexistent-id")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "error" in body
+        assert "code" in body
+
+
+class TestDeleteKnowledge:
+    """DELETE /v1/knowledge/:id"""
+
+    async def test_delete_existing_entry(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+        resp = await client.delete(f"/v1/knowledge/{entry['id']}")
+        assert resp.status_code == 204
+
+        # Verify it's gone
+        resp = await client.get(f"/v1/knowledge/{entry['id']}")
+        assert resp.status_code == 404
+
+    async def test_delete_nonexistent_entry(self, client):
+        resp = await client.delete("/v1/knowledge/nonexistent-id")
+        assert resp.status_code == 404
+
+
+class TestListKnowledge:
+    """GET /v1/knowledge?user_id=..."""
+
+    async def test_list_entries(self, client, make_knowledge_entry):
+        # Create 3 entries for user-1
+        uuids = [
+            "11111111-1111-4111-a111-111111111111",
+            "22222222-2222-4222-a222-222222222222",
+            "33333333-3333-4333-a333-333333333333",
+        ]
+        for i in range(3):
+            entry = make_knowledge_entry(user_id="user-1")
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        # Create 1 entry for user-2
+        entry2 = make_knowledge_entry(user_id="user-2")
+        entry2["id"] = "44444444-4444-4444-a444-444444444444"
+        resp = await client.post("/v1/knowledge", json=entry2)
+        assert resp.status_code == 201
+
+        # List user-1 should return 3
+        resp = await client.get("/v1/knowledge", params={"user_id": "user-1"})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+        # List user-2 should return 1
+        resp = await client.get("/v1/knowledge", params={"user_id": "user-2"})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    async def test_list_with_category_filter(self, client, make_knowledge_entry):
+        uuids = [
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        ]
+        for i, cat in enumerate(["fact", "preference", "correction"]):
+            entry = make_knowledge_entry(user_id="user-filter", category=cat)
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201, f"Failed to create {cat}: {resp.json()}"
+
+        resp = await client.get(
+            "/v1/knowledge",
+            params={"user_id": "user-filter", "category": "fact"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["category"] == "fact"
+
+    async def test_list_pagination(self, client, make_knowledge_entry):
+        uuids = [
+            "d0000000-d000-4d00-8d00-d00000000001",
+            "d0000000-d000-4d00-8d00-d00000000002",
+            "d0000000-d000-4d00-8d00-d00000000003",
+            "d0000000-d000-4d00-8d00-d00000000004",
+            "d0000000-d000-4d00-8d00-d00000000005",
+        ]
+        for i in range(5):
+            entry = make_knowledge_entry(user_id="user-page")
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        # Page 1: limit=2, offset=0
+        resp = await client.get(
+            "/v1/knowledge",
+            params={"user_id": "user-page", "limit": 2, "offset": 0},
+        )
+        assert len(resp.json()) == 2
+
+        # Page 2: limit=2, offset=2
+        resp = await client.get(
+            "/v1/knowledge",
+            params={"user_id": "user-page", "limit": 2, "offset": 2},
+        )
+        assert len(resp.json()) == 2
+
+        # Page 3: limit=2, offset=4
+        resp = await client.get(
+            "/v1/knowledge",
+            params={"user_id": "user-page", "limit": 2, "offset": 4},
+        )
+        assert len(resp.json()) == 1

--- a/reference/server/tests/test_knowledge_search.py
+++ b/reference/server/tests/test_knowledge_search.py
@@ -1,0 +1,98 @@
+"""Tests for search endpoint."""
+
+from __future__ import annotations
+
+
+class TestSearchKnowledge:
+    """GET /v1/knowledge/search?q=...&user_id=..."""
+
+    async def test_search_by_content(self, client, make_knowledge_entry):
+        uuids = [
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        ]
+        for i, (content, _) in enumerate([("Rust programming", 1), ("Python scripting", 2), ("Go concurrency", 3)]):
+            entry = make_knowledge_entry(
+                user_id="user-search",
+                content=content,
+            )
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Rust", "user_id": "user-search"},
+        )
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 1
+        assert "Rust" in results[0]["content"]
+
+    async def test_search_case_insensitive(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(user_id="user-ci", content="Concurrent Processing")
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "concurrent", "user_id": "user-ci"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    async def test_search_scoped_to_user(self, client, make_knowledge_entry):
+        # User A has knowledge about Rust
+        entry_a = make_knowledge_entry(user_id="user-a", content="Rust is great")
+        entry_a["id"] = "f0000001-e29b-41d4-a716-446655440000"
+        resp = await client.post("/v1/knowledge", json=entry_a)
+        assert resp.status_code == 201
+
+        # User B has knowledge about Rust too
+        entry_b = make_knowledge_entry(user_id="user-b", content="Rust is fast")
+        entry_b["id"] = "f0000002-e29b-41d4-a716-446655440000"
+        resp = await client.post("/v1/knowledge", json=entry_b)
+        assert resp.status_code == 201
+
+        # Search user-a should only return user-a's entry
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Rust", "user_id": "user-a"},
+        )
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["user_id"] == "user-a"
+
+    async def test_search_with_category_filter(self, client, make_knowledge_entry):
+        uuids = [
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        ]
+        for i, cat in enumerate(["fact", "preference"]):
+            entry = make_knowledge_entry(
+                user_id="user-search-cat",
+                category=cat,
+                content=f"This is a {cat} about Rust",
+            )
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Rust", "user_id": "user-search-cat", "category": "fact"},
+        )
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["category"] == "fact"
+
+    async def test_search_no_results(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(user_id="user-empty", content="Rust is great")
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "quantum computing", "user_id": "user-empty"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 0

--- a/reference/server/tests/test_search_fts5.py
+++ b/reference/server/tests/test_search_fts5.py
@@ -1,0 +1,101 @@
+"""Tests for FTS5-specific search behavior."""
+
+from __future__ import annotations
+
+
+class TestFTS5Search:
+    """FTS5 full-text search with Porter stemming."""
+
+    async def test_search_porter_stemming(self, client, make_knowledge_entry):
+        """FTS5 with Porter stemmer should match stemmed forms.
+
+        E.g., searching 'programming' should find 'programs', 'programmed', etc.
+        """
+        entry = make_knowledge_entry(
+            user_id="user-stem",
+            content="The user programs in Rust and Go",
+        )
+        entry["id"] = "f0000001-e29b-41d4-a716-446655440001"
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+        # Search with a different form of the word
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "programming", "user_id": "user-stem"},
+        )
+        assert resp.status_code == 200
+        results = resp.json()
+        # Porter stemmer should match "programs" when searching "programming"
+        assert len(results) >= 1
+
+    async def test_search_multi_word_query(self, client, make_knowledge_entry):
+        """Multi-word FTS5 queries should work."""
+        entry = make_knowledge_entry(
+            user_id="user-multi",
+            content="Kubernetes deployment with Helm charts",
+        )
+        entry["id"] = "f0000002-e29b-41d4-a716-446655440002"
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+        # Search with multiple words
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Kubernetes Helm", "user_id": "user-multi"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    async def test_search_partial_word(self, client, make_knowledge_entry):
+        """Test that search works for exact word matches."""
+        entry = make_knowledge_entry(
+            user_id="user-partial",
+            content="Docker container orchestration",
+        )
+        entry["id"] = "f0000003-e29b-41d4-a716-446655440003"
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Docker", "user_id": "user-partial"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    async def test_search_returns_empty_for_no_match(self, client, make_knowledge_entry):
+        """Search for something that doesn't exist returns empty list."""
+        entry = make_knowledge_entry(
+            user_id="user-no-match",
+            content="PostgreSQL transaction isolation levels",
+        )
+        entry["id"] = "f0000004-e29b-41d4-a716-446655440004"
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "quantum entanglement", "user_id": "user-no-match"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 0
+
+    async def test_search_with_pagination(self, client, make_knowledge_entry):
+        """Search results should respect limit/offset."""
+        for i in range(5):
+            entry = make_knowledge_entry(
+                user_id="user-search-page",
+                content=f"Rust memory safety topic {i}",
+            )
+            entry["id"] = f"f{i+1:07d}-e29b-41d4-a716-446655440000"
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        # Limit to 2 results
+        resp = await client.get(
+            "/v1/knowledge/search",
+            params={"q": "Rust", "user_id": "user-search-page", "limit": 2},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2

--- a/reference/server/tests/test_user_model.py
+++ b/reference/server/tests/test_user_model.py
@@ -1,0 +1,142 @@
+"""Tests for user model CRUD endpoints."""
+
+from __future__ import annotations
+
+
+class TestCreateUserModel:
+    """POST /v1/user-model"""
+
+    async def test_create_valid_model(self, client, make_user_model):
+        model = make_user_model()
+        resp = await client.post("/v1/user-model", json=model)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["user_id"] == model["user_id"]
+        assert data["model_version"] == model["model_version"]
+
+    async def test_create_with_communication(self, client, make_user_model):
+        model = make_user_model()
+        model["communication"] = {
+            "verbosity": -0.6,
+            "formality": 0.2,
+            "prefers_examples": True,
+            "prefers_explanations": False,
+            "languages": ["en", "ja"],
+        }
+        resp = await client.post("/v1/user-model", json=model)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["communication"]["verbosity"] == -0.6
+        assert data["communication"]["languages"] == ["en", "ja"]
+
+    async def test_create_with_expertise(self, client, make_user_model):
+        model = make_user_model()
+        model["expertise"] = [
+            {
+                "domain": "rust",
+                "level": "expert",
+                "confidence": 0.95,
+                "evidence_sessions": ["sess-001"],
+                "last_observed": "2026-03-28T09:00:00Z",
+            }
+        ]
+        resp = await client.post("/v1/user-model", json=model)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data["expertise"]) == 1
+        assert data["expertise"][0]["domain"] == "rust"
+
+
+class TestGetUserModel:
+    """GET /v1/user-model/:user_id"""
+
+    async def test_get_existing_model(self, client, make_user_model):
+        model = make_user_model()
+        await client.post("/v1/user-model", json=model)
+        resp = await client.get(f"/v1/user-model/{model['user_id']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == model["user_id"]
+
+    async def test_get_nonexistent_model(self, client):
+        resp = await client.get("/v1/user-model/nonexistent-user")
+        assert resp.status_code == 404
+
+
+class TestDeleteUserModel:
+    """DELETE /v1/user-model/:user_id"""
+
+    async def test_delete_existing_model(self, client, make_user_model):
+        model = make_user_model(user_id="user-delete")
+        await client.post("/v1/user-model", json=model)
+        resp = await client.delete(f"/v1/user-model/{model['user_id']}")
+        assert resp.status_code == 204
+
+        # Verify model is gone
+        resp = await client.get(f"/v1/user-model/{model['user_id']}")
+        assert resp.status_code == 404
+
+    async def test_delete_also_removes_knowledge(self, client, make_user_model, make_knowledge_entry):
+        """Spec Section 6.3: MUST delete all associated Knowledge Entries."""
+        user_id = "user-delete-all"
+        model = make_user_model(user_id=user_id)
+        resp = await client.post("/v1/user-model", json=model)
+        assert resp.status_code == 201
+
+        # Create knowledge entries for this user
+        uuids = [
+            "e0000001-e29b-41d4-a716-446655440000",
+            "e0000002-e29b-41d4-a716-446655440000",
+            "e0000003-e29b-41d4-a716-446655440000",
+        ]
+        for i in range(3):
+            entry = make_knowledge_entry(user_id=user_id)
+            entry["id"] = uuids[i]
+            resp = await client.post("/v1/knowledge", json=entry)
+            assert resp.status_code == 201
+
+        # Delete the user model — should remove everything
+        resp = await client.delete(f"/v1/user-model/{user_id}")
+        assert resp.status_code == 204
+
+        # Verify knowledge is also gone
+        resp = await client.get("/v1/knowledge", params={"user_id": user_id})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 0
+
+    async def test_delete_nonexistent_model(self, client):
+        resp = await client.delete("/v1/user-model/nonexistent-user")
+        assert resp.status_code == 404
+
+
+class TestVersionMonotonicity:
+    """POST /v1/user-model with version conflict"""
+
+    async def test_update_with_higher_version(self, client, make_user_model):
+        """Updating with model_version > stored should succeed."""
+        model_v1 = make_user_model(user_id="user-version")
+        await client.post("/v1/user-model", json=model_v1)
+
+        model_v2 = make_user_model(user_id="user-version", model_version=2)
+        resp = await client.post("/v1/user-model", json=model_v2)
+        assert resp.status_code == 200
+        assert resp.json()["model_version"] == 2
+
+    async def test_update_with_same_version_fails(self, client, make_user_model):
+        """Spec Section 5.1: MUST reject if model_version <= stored version."""
+        model_v7 = make_user_model(user_id="user-conflict", model_version=7)
+        await client.post("/v1/user-model", json=model_v7)
+
+        model_v7_again = make_user_model(user_id="user-conflict", model_version=7)
+        resp = await client.post("/v1/user-model", json=model_v7_again)
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body.get("code") == "VERSION_CONFLICT"
+
+    async def test_update_with_lower_version_fails(self, client, make_user_model):
+        model_v5 = make_user_model(user_id="user-conflict-low", model_version=5)
+        await client.post("/v1/user-model", json=model_v5)
+
+        model_v3 = make_user_model(user_id="user-conflict-low", model_version=3)
+        resp = await client.post("/v1/user-model", json=model_v3)
+        assert resp.status_code == 409

--- a/reference/server/tests/test_validation.py
+++ b/reference/server/tests/test_validation.py
@@ -1,0 +1,123 @@
+"""Tests for error handling compliance."""
+
+from __future__ import annotations
+
+
+class TestErrorFormat:
+    """Spec Section 6.8: All errors MUST be JSON with 'error' and 'code'."""
+
+    async def test_error_format_on_not_found(self, client):
+        resp = await client.get("/v1/knowledge/nonexistent-id")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "error" in body
+        assert "code" in body
+        assert isinstance(body["error"], str)
+        assert isinstance(body["code"], str)
+
+    async def test_error_format_on_validation_error(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry(confidence=5.0)
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "error" in body
+        assert "code" in body
+        assert body["code"] == "VALIDATION_ERROR"
+
+    async def test_error_format_on_version_conflict(self, client, make_user_model):
+        model = make_user_model(user_id="user-err", model_version=3)
+        await client.post("/v1/user-model", json=model)
+
+        # Try with same version
+        model_same = make_user_model(user_id="user-err", model_version=3)
+        resp = await client.post("/v1/user-model", json=model_same)
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["code"] == "VERSION_CONFLICT"
+
+    async def test_error_format_on_forbidden_patch(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        resp = await client.post("/v1/knowledge", json=entry)
+        assert resp.status_code == 201
+
+        # Try to patch a forbidden field
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"category": "preference"},  # category is forbidden to patch
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["code"] == "FORBIDDEN_PATCH"
+
+
+class TestPatchKnowledge:
+    """PATCH /v1/knowledge/:id"""
+
+    async def test_patch_confidence(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"confidence": 0.95},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["confidence"] == 0.95
+
+    async def test_patch_tags(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"tags": ["updated", "tags"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["updated", "tags"]
+
+    async def test_patch_forbidden_id(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"id": "new-id"},
+        )
+        assert resp.status_code == 400
+
+    async def test_patch_forbidden_user_id(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"user_id": "different-user"},
+        )
+        assert resp.status_code == 400
+
+    async def test_patch_forbidden_category(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"category": "preference"},
+        )
+        assert resp.status_code == 400
+
+    async def test_patch_forbidden_source(self, client, make_knowledge_entry):
+        entry = make_knowledge_entry()
+        await client.post("/v1/knowledge", json=entry)
+
+        resp = await client.patch(
+            f"/v1/knowledge/{entry['id']}",
+            json={"source": {"session_id": "new-sess"}},
+        )
+        assert resp.status_code == 400
+
+    async def test_patch_nonexistent_entry(self, client):
+        resp = await client.patch(
+            "/v1/knowledge/nonexistent-id",
+            json={"confidence": 0.5},
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Reference Backend Server

FastAPI-based OAMP reference backend with SQLite persistence and FTS5 search.

### Endpoints (12 total)

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/v1/knowledge` | Create KnowledgeEntry (201) |
| GET | `/v1/knowledge` | List entries (category filter, pagination) |
| GET | `/v1/knowledge/search` | FTS5 full-text search with Porter stemming |
| GET | `/v1/knowledge/{id}` | Get entry by ID |
| PATCH | `/v1/knowledge/{id}` | Update confidence/tags/decay |
| DELETE | `/v1/knowledge/{id}` | Delete entry (204) |
| POST | `/v1/user-model` | Create (201) or update (200) model |
| GET | `/v1/user-model/{user_id}` | Get model |
| DELETE | `/v1/user-model/{user_id}` | Delete model + all knowledge (204) |
| GET | `/v1/export/{user_id}` | Bulk export as KnowledgeStore |
| POST | `/v1/import` | Bulk import KnowledgeStore |
| GET | `/health` | Health check |

### Architecture

- **SQLite** with `aiosqlite` async I/O for persistence
- **FTS5** full-text search with Porter stemming (standalone table, no content-sync)
- **FastAPI** with async lifespan for DB init/teardown
- **Pydantic v2** models from `oamp-types` for request/response validation
- **3-layer architecture**: API → Service → Repository

### Test Coverage (59 tests)

- Knowledge CRUD (13 tests)
- Knowledge search — basic + FTS5 (10 tests)
- User model CRUD (9 tests)
- Validation & error format (9 tests)
- Bulk export/import (8 tests)
- Health + spec example round-trips (4 tests)
- Spec-compliant error responses (`error` + `code` fields)

### Key Decisions

- Standalone FTS5 table (no content-sync triggers — avoids INSERT OR REPLACE fragility)
- Python-side timestamps (SQLite `datetime()` not allowed as column default)
- Factory fixtures for test data generation
- In-memory SQLite for tests with proper async lifecycle
- `UserModelService.create_or_update()` returns `(created, model)` tuple to avoid repo access from API layer

### Phase Status

- [x] **Phase 1**: FastAPI skeleton, SQLite repo, Knowledge/UserModel CRUD
- [x] **Phase 2**: FTS5 search, bulk export/import, PATCH endpoint
- [ ] **Phase 3**: AES-256-GCM encryption at rest (future PR)
- [ ] **Phase 4**: Docker, performance benchmarks (future PR)

### All test suites passing

- Rust: 10/10 ✅
- TypeScript: 7/7 ✅
- Python: 46/46 ✅
- Go: 21/21 ✅
- Elixir: 26/26 ✅
- **Server: 59/59 ✅**