### PR TITLE
Promote OAMP v1.1 and v1.2 from draft to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.2.0-draft] — 2026-05-07
+## [1.2.0] — 2026-05-09
+
+Cross-impl interop verified 2026-05-09: kizuna-mem ↔ cosmictron, both
+directions produce empty diffs against `spec/v1.2/examples/` and
+`validators/test-fixtures/valid/`. Conformance pressure-test passed; v1.2
+promoted from draft.
 
 ### Added (proposed, draft for community review)
-- **`spec/v1.2/oamp-v1.2-governed-memory-draft.md`** — design rationale for
+- **`spec/v1.2/oamp-v1.2-governed-memory.md`** — design rationale for
   governed-memory standardization across OAMP backends used by `cosmictron`,
   `kizuna-mem`, `ultra`, and `toraeru`.
-- **`spec/v1.2/oamp-v1.2-draft.md`** — normative draft that ratifies the
+- **`spec/v1.2/oamp-v1.2.md`** — normative spec that ratifies the
   working split: v1.2 standardizes additive governance metadata, richer
   provenance, and discovery/filter semantics, while withheld/redacted result
   documents are explicitly deferred to a separate v2.0 design track.
@@ -78,10 +83,10 @@ All notable changes to this project will be documented in this file.
 - Portable `withholding_reason` envelopes
 - Stream-level withheld event payloads
 
-## [1.1.0-draft] — 2026-05-02
+## [1.1.0] — 2026-05-09
 
 ### Added (proposed, draft for community review)
-- **`spec/v1.1/oamp-v1.1-draft.md`** — Strictly additive minor version
+- **`spec/v1.1/oamp-v1.1.md`** — Strictly additive minor version
   introducing two OPTIONAL capabilities and a capabilities-discovery
   endpoint. No breaking changes; v1.0 clients remain wire-compatible.
 - **Capabilities discovery endpoint** (`GET /v1/capabilities`) — lets

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [Stable Spec](spec/v1/oamp-v1.md) | [Latest Draft](spec/v1.3/oamp-v1.3-draft.md) | [Rust](reference/rust/) | [TypeScript](reference/typescript/) | [Python](reference/python/) | [Go](reference/go/) | [Elixir](reference/elixir/) | [Security Guide](docs/security-guide.md)
 
-Draft extensions: [v1.1](spec/v1.1/oamp-v1.1-draft.md) | [v1.2 governed memory metadata](spec/v1.2/oamp-v1.2-draft.md) | [v1.3 governed memory enforcement](spec/v1.3/oamp-v1.3-draft.md)
+Stable extensions: [v1.1](spec/v1.1/oamp-v1.1.md) | [v1.2 governed memory metadata](spec/v1.2/oamp-v1.2.md). Draft: [v1.3 governed memory enforcement](spec/v1.3/oamp-v1.3-draft.md)
 
 The reference Python, TypeScript, Rust, Go, and Elixir libraries all parse the additive governed-memory entry/store shape used by both the `v1.2` and `v1.3` draft lines.
 
@@ -247,10 +247,10 @@ spec/v1/
   examples/                Valid example documents
 
 spec/v1.1/
-  oamp-v1.1-draft.md       Optional capabilities draft (streaming + as_of)
+  oamp-v1.1.md             Optional capabilities (streaming + as_of)
 
 spec/v1.2/
-  oamp-v1.2-draft.md       Governed-memory draft
+  oamp-v1.2.md             Governed-memory metadata
   *.schema.json            Additive v1.2 schema definitions
   examples/                Governed-memory example documents
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,7 +4,7 @@
 
 ### AIエージェントの記憶は、あなたのものであるべきです。
 
-[![Spec Version](https://img.shields.io/badge/spec-v1.2.0--draft-blue.svg)](../spec/v1.2/oamp-v1.2-draft.md)
+[![Spec Version](https://img.shields.io/badge/spec-v1.2.0-blue.svg)](../spec/v1.2/oamp-v1.2.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/npm/v/@deepthinking/oamp-types.svg)](https://www.npmjs.com/package/@deepthinking/oamp-types)
@@ -241,10 +241,10 @@ spec/v1/
   examples/                有効なサンプルドキュメント
 
 spec/v1.1/
-  oamp-v1.1-draft.md       オプショナル機能のドラフト（streaming + as_of）
+  oamp-v1.1.md             オプショナル機能（streaming + as_of）
 
 spec/v1.2/
-  oamp-v1.2-draft.md       Governed-memory ドラフト
+  oamp-v1.2.md             Governed-memory メタデータ
   *.schema.json            追加的な v1.2 スキーマ定義
   examples/                Governed-memory のサンプルドキュメント
 
@@ -313,11 +313,11 @@ OAMP準拠のメモリストアを構築：
 | | |
 |:---|:---|
 | **現在の安定版** | v1.0.0 |
-| **最新ドラフト版** | v1.2.0-draft |
+| **最新安定版** | v1.2.0 |
 | **スキーマ形式** | JSON Schema (draft-2020-12) + Protocol Buffers |
 | **準拠言語** | RFC 2119 (MUST, SHOULD, MAY) |
 | **安定版仕様** | [spec/v1/oamp-v1.md](../spec/v1/oamp-v1.md) |
-| **最新ドラフト仕様** | [spec/v1.2/oamp-v1.2-draft.md](../spec/v1.2/oamp-v1.2-draft.md) |
+| **最新安定仕様** | [spec/v1.2/oamp-v1.2.md](../spec/v1.2/oamp-v1.2.md) |
 
 ### v2.0の計画
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -4,7 +4,7 @@
 
 ### AI 에이전트의 메모리는 당신의 것이어야 합니다.
 
-[![Spec Version](https://img.shields.io/badge/spec-v1.2.0--draft-blue.svg)](../spec/v1.2/oamp-v1.2-draft.md)
+[![Spec Version](https://img.shields.io/badge/spec-v1.2.0-blue.svg)](../spec/v1.2/oamp-v1.2.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/npm/v/@deepthinking/oamp-types.svg)](https://www.npmjs.com/package/@deepthinking/oamp-types)
@@ -241,10 +241,10 @@ spec/v1/
   examples/                유효한 예제 문서
 
 spec/v1.1/
-  oamp-v1.1-draft.md       선택적 기능 초안 (streaming + as_of)
+  oamp-v1.1.md             선택적 기능 (streaming + as_of)
 
 spec/v1.2/
-  oamp-v1.2-draft.md       Governed-memory 초안
+  oamp-v1.2.md             Governed-memory 메타데이터
   *.schema.json            추가형 v1.2 스키마 정의
   examples/                Governed-memory 예제 문서
 
@@ -313,11 +313,11 @@ OAMP 호환 메모리 저장소를 구축하세요:
 | | |
 |:---|:---|
 | **현재 안정 버전** | v1.0.0 |
-| **최신 초안 버전** | v1.2.0-draft |
+| **최신 안정 버전** | v1.2.0 |
 | **스키마 형식** | JSON Schema (draft-2020-12) + Protocol Buffers |
 | **준수 언어** | RFC 2119 (MUST, SHOULD, MAY) |
 | **안정 사양** | [spec/v1/oamp-v1.md](../spec/v1/oamp-v1.md) |
-| **최신 초안 사양** | [spec/v1.2/oamp-v1.2-draft.md](../spec/v1.2/oamp-v1.2-draft.md) |
+| **최신 안정 사양** | [spec/v1.2/oamp-v1.2.md](../spec/v1.2/oamp-v1.2.md) |
 
 ### v2.0 계획
 

--- a/docs/README.ms.md
+++ b/docs/README.ms.md
@@ -4,7 +4,7 @@
 
 ### Memori ejen AI anda sepatutnya menjadi milik anda.
 
-[![Spec Version](https://img.shields.io/badge/spec-v1.2.0--draft-blue.svg)](../spec/v1.2/oamp-v1.2-draft.md)
+[![Spec Version](https://img.shields.io/badge/spec-v1.2.0-blue.svg)](../spec/v1.2/oamp-v1.2.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/npm/v/@deepthinking/oamp-types.svg)](https://www.npmjs.com/package/@deepthinking/oamp-types)
@@ -241,10 +241,10 @@ spec/v1/
   examples/                Dokumen contoh yang sah
 
 spec/v1.1/
-  oamp-v1.1-draft.md       Draf keupayaan pilihan (streaming + as_of)
+  oamp-v1.1.md             Keupayaan pilihan (streaming + as_of)
 
 spec/v1.2/
-  oamp-v1.2-draft.md       Draf governed-memory
+  oamp-v1.2.md             Metadata governed-memory
   *.schema.json            Definisi skema v1.2 tambahan
   examples/                Dokumen contoh governed-memory
 
@@ -313,11 +313,11 @@ Bina stor memori patuh OAMP:
 | | |
 |:---|:---|
 | **Versi stabil semasa** | v1.0.0 |
-| **Versi draf terkini** | v1.2.0-draft |
+| **Versi stabil terkini** | v1.2.0 |
 | **Format skema** | JSON Schema (draft-2020-12) + Protocol Buffers |
 | **Bahasa pematuhan** | RFC 2119 (MUST, SHOULD, MAY) |
 | **Spesifikasi stabil** | [spec/v1/oamp-v1.md](../spec/v1/oamp-v1.md) |
-| **Spesifikasi draf terkini** | [spec/v1.2/oamp-v1.2-draft.md](../spec/v1.2/oamp-v1.2-draft.md) |
+| **Spesifikasi stabil terkini** | [spec/v1.2/oamp-v1.2.md](../spec/v1.2/oamp-v1.2.md) |
 
 ### Dirancang untuk v2.0
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -4,7 +4,7 @@
 
 ### 你的 AI 智能体的记忆，应该属于你自己。
 
-[![Spec Version](https://img.shields.io/badge/spec-v1.2.0--draft-blue.svg)](../spec/v1.2/oamp-v1.2-draft.md)
+[![Spec Version](https://img.shields.io/badge/spec-v1.2.0-blue.svg)](../spec/v1.2/oamp-v1.2.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE)
 [![Rust Crate](https://img.shields.io/badge/crate-oamp--types-orange.svg)](../reference/rust/)
 [![npm Package](https://img.shields.io/npm/v/@deepthinking/oamp-types.svg)](https://www.npmjs.com/package/@deepthinking/oamp-types)
@@ -241,10 +241,10 @@ spec/v1/
   examples/                有效的示例文档
 
 spec/v1.1/
-  oamp-v1.1-draft.md       可选能力草案（streaming + as_of）
+  oamp-v1.1.md             可选能力（streaming + as_of）
 
 spec/v1.2/
-  oamp-v1.2-draft.md       Governed-memory 草案
+  oamp-v1.2.md             Governed-memory 元数据
   *.schema.json            增量式 v1.2 Schema 定义
   examples/                Governed-memory 示例文档
 
@@ -313,11 +313,11 @@ docs/
 | | |
 |:---|:---|
 | **当前稳定版本** | v1.0.0 |
-| **最新草案版本** | v1.2.0-draft |
+| **最新稳定版本** | v1.2.0 |
 | **Schema 格式** | JSON Schema (draft-2020-12) + Protocol Buffers |
 | **合规语言** | RFC 2119 (MUST, SHOULD, MAY) |
 | **稳定规范** | [spec/v1/oamp-v1.md](../spec/v1/oamp-v1.md) |
-| **最新草案规范** | [spec/v1.2/oamp-v1.2-draft.md](../spec/v1.2/oamp-v1.2-draft.md) |
+| **最新稳定规范** | [spec/v1.2/oamp-v1.2.md](../spec/v1.2/oamp-v1.2.md) |
 
 ### v2.0 计划
 

--- a/docs/governed-memory-issue-backlog.md
+++ b/docs/governed-memory-issue-backlog.md
@@ -5,8 +5,8 @@ sequence for OAMP.
 
 Related drafts:
 
-- `spec/v1.2/oamp-v1.2-governed-memory-draft.md`
-- `spec/v1.2/oamp-v1.2-draft.md`
+- `spec/v1.2/oamp-v1.2-governed-memory.md`
+- `spec/v1.2/oamp-v1.2.md`
 - `spec/v1.3/oamp-v1.3-draft.md`
 - `spec/v2.0/oamp-v2.0-withheld-results-rfc.md`
 
@@ -67,7 +67,7 @@ Acceptance criteria:
 
 Files:
 
-- `spec/v1.2/oamp-v1.2-governed-memory-draft.md`
+- `spec/v1.2/oamp-v1.2-governed-memory.md`
 - any consolidated capabilities spec text
 
 Acceptance criteria:

--- a/docs/guide-for-backends.md
+++ b/docs/guide-for-backends.md
@@ -73,6 +73,6 @@ Support at minimum `application/json`. Optionally support `application/protobuf`
 
 If your backend implements governed memory today, the recommended path is:
 
-1. Preserve `governance` and `provenance` per `spec/v1.2/oamp-v1.2-draft.md`
+1. Preserve `governance` and `provenance` per `spec/v1.2/oamp-v1.2.md`
 2. Advertise `capabilities.governance`
 3. Add `capabilities.governance.enforcement` and enforce grant-based filtering per `spec/v1.3/oamp-v1.3-draft.md`

--- a/reference/compliance/src/oamp_compliance/reporter.py
+++ b/reference/compliance/src/oamp_compliance/reporter.py
@@ -13,7 +13,7 @@ from .tests.utils import TestResult
 
 
 REPORT_SPEC_LINE = "v1.x"
-REPORT_SPEC_COVERAGE = "stable v1.0.0 + additive v1.2.0-draft and v1.3.0-draft coverage"
+REPORT_SPEC_COVERAGE = "stable v1.0.0 + additive v1.1.0 + additive v1.2.0 and v1.3.0-draft coverage"
 
 
 def generate_report(

--- a/spec/proposals/2026-05-07-permissioned-memory-v1.3.md
+++ b/spec/proposals/2026-05-07-permissioned-memory-v1.3.md
@@ -5,7 +5,7 @@
 **Date:** 2026-05-07
 **Authors:** Deep Thinking LLC
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
-**Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1-draft.md`, `spec/v1.2/oamp-v1.2-draft.md`, `spec/v1.2/oamp-v1.2-governed-memory-draft.md`
+**Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1.md`, `spec/v1.2/oamp-v1.2.md`, `spec/v1.2/oamp-v1.2-governed-memory.md`
 **Related:** `spec/v2.0/oamp-v2.0-withheld-results-rfc.md`
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
@@ -20,7 +20,7 @@ OAMP v1.2 introduced standardized **descriptive** governed-memory metadata
 (`governance.sensitivity_class`, `governance.labels`, `governance.handling`)
 on `KnowledgeEntry`. The v1.2 draft is explicit that `governance` is
 descriptive and "is not a portable policy engine"
-(`spec/v1.2/oamp-v1.2-draft.md` §3.1).
+(`spec/v1.2/oamp-v1.2.md` §3.1).
 
 This proposal targets v1.3 and adds the **enforcement** layer that
 operationalises v1.2's descriptive metadata. It defines a portable agent

--- a/spec/v1.1/oamp-v1.1.md
+++ b/spec/v1.1/oamp-v1.1.md
@@ -1,7 +1,7 @@
-# Open Agent Memory Protocol — Version 1.1.0 (Draft)
+# Open Agent Memory Protocol — Version 1.1.0
 
-**Status:** Draft (proposed minor version)
-**Date:** 2026-05-02
+**Status:** Stable
+**Date:** 2026-05-09
 **Authors:** Deep Thinking LLC
 **Supersedes:** None — extends v1.0.0 additively
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`

--- a/spec/v1.2/oamp-v1.2-governed-memory.md
+++ b/spec/v1.2/oamp-v1.2-governed-memory.md
@@ -1,10 +1,10 @@
-# Open Agent Memory Protocol — Governed Memory Proposal for v1.2
+# Open Agent Memory Protocol — Governed Memory for v1.2
 
-**Status:** Draft proposal
-**Date:** 2026-05-07
+**Status:** Stable
+**Date:** 2026-05-09
 **Authors:** Deep Thinking LLC
 **Related implementations:** `cosmictron`, `kizuna-mem`, `ultra`, `toraeru`
-**Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1-draft.md`
+**Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1.md`
 
 ---
 
@@ -326,7 +326,7 @@ Files:
 
 Files:
 
-- `spec/v1.2/oamp-v1.2-draft.md`
+- `spec/v1.2/oamp-v1.2.md`
 - `spec/v1.2/openapi.yaml`
 - v1.1 capabilities text if reused or superseded
 

--- a/spec/v1.2/oamp-v1.2.md
+++ b/spec/v1.2/oamp-v1.2.md
@@ -1,7 +1,7 @@
-# Open Agent Memory Protocol — Version 1.2.0 (Draft)
+# Open Agent Memory Protocol — Version 1.2.0
 
-**Status:** Draft (proposed minor version)  
-**Date:** 2026-05-07  
+**Status:** Stable  
+**Date:** 2026-05-09  
 **Authors:** Deep Thinking LLC  
 **Supersedes:** None — extends v1.0.0 and v1.1.0 additively  
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`

--- a/spec/v1.2/openapi.yaml
+++ b/spec/v1.2/openapi.yaml
@@ -8,7 +8,7 @@ info:
 
     Endpoints and response shapes not repeated here inherit their definitions
     from `spec/v1/openapi.yaml`.
-  version: "1.2.0-draft"
+  version: "1.2.0"
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT


### PR DESCRIPTION
## Summary

Promotes OAMP v1.1 and v1.2 from draft to stable. v1.3 stays in draft (no second conformant implementation yet).

Both v1.1 and v1.2 now have two conformant reference implementations (`cosmictron`, `kizuna-mem`) with cross-impl interop verified clean in both directions on **2026-05-09** against `spec/v1.2/examples/` and `validators/test-fixtures/valid/`. Tracking issue closed upstream as `kizuna-dream#18` (fix commit `6b21e4f6`) and `kizuna-dream#14`. v1.1 and v1.2 promotion triggers in this repo's standing rules are now both met.

## Changes

### Renames (history preserved via `git mv`)
- `spec/v1.1/oamp-v1.1-draft.md` → `spec/v1.1/oamp-v1.1.md`
- `spec/v1.2/oamp-v1.2-draft.md` → `spec/v1.2/oamp-v1.2.md`
- `spec/v1.2/oamp-v1.2-governed-memory-draft.md` → `spec/v1.2/oamp-v1.2-governed-memory.md`

### Header updates (in renamed files)
- v1.1 spec: title dropped "(Draft)", `Status: Stable`, dated 2026-05-09
- v1.2 spec: title dropped "(Draft)", `Status: Stable`, dated 2026-05-09
- v1.2 governed-memory: title dropped "Proposal for", `Status: Stable`, dated 2026-05-09, `Depends on:` updated to renamed v1.1 path

### CHANGELOG.md
- `[1.2.0-draft] — 2026-05-07` → `[1.2.0] — 2026-05-09`, with the cross-impl interop verification paragraph appended at the top of the entry; bullet paths updated to renamed filenames
- `[1.1.0-draft] — 2026-05-02` → `[1.1.0] — 2026-05-09`; bullet path updated
- `[1.3.0-draft]` left untouched (still in draft)

### Cross-references updated (11 files)
| File | What changed |
|---|---|
| `README.md` | "Draft extensions" line + `spec/v1.1/`+`spec/v1.2/` directory legend |
| `docs/README.zh.md` | spec-version badge, directory legend, "latest version" table rows |
| `docs/README.ja.md` | same set of 4 references |
| `docs/README.ko.md` | same set of 4 references |
| `docs/README.ms.md` | same set of 4 references |
| `docs/governed-memory-issue-backlog.md` | 3 path mentions |
| `docs/guide-for-backends.md` | recommended-path step 1 |
| `spec/proposals/2026-05-07-permissioned-memory-v1.3.md` | `Depends on:` line + §3.1 cross-ref |
| `spec/v1.2/oamp-v1.2-governed-memory.md` | self-cross-ref to renamed v1.2 spec |
| `spec/v1.2/openapi.yaml` | `info.version: "1.2.0-draft"` → `"1.2.0"` |
| `reference/compliance/src/oamp_compliance/reporter.py` | `REPORT_SPEC_COVERAGE` updated; also fixed a pre-existing omission (v1.1 was missing entirely from the coverage string) |

`grep` over the main tree for `oamp-v1.1-draft` / `oamp-v1.2-draft` / `oamp-v1.2-governed-memory-draft` / `1.2.0-draft` / `1.1.0-draft` returns zero matches.

### v1.3 untouched
`spec/v1.3/` is unchanged. The `[1.3.0-draft]` heading in `CHANGELOG.md` and all `oamp-v1.3-draft.md` references stay as-is.

## Verification log (2026-05-09)

### Validator (`validators/validate.sh` over v1.2 fixtures)
- `spec/v1.2/examples/knowledge-entry-governed.json` — **OK**
- `spec/v1.2/examples/knowledge-entry-provenance.json` — **OK**
- `spec/v1.2/examples/knowledge-store-governed.json` — **OK**
- `spec/v1.2/examples/knowledge-store-interop.json` — **OK**
- `spec/v1.2/examples/capabilities-governance.json` — not validated by `validate.sh` (no `type` field; that script auto-detects schema by `type`, and capability docs aren't typed knowledge documents). Not a regression.
- `validators/test-fixtures/valid/v1.2-*.json` (4 fixtures) — all **OK**

### Cross-language reference test suites
| Suite | Result |
|---|---|
| `reference/python` | **48 passed** (`pytest -q`) |
| `reference/rust` | **13 passed**, 0 failed (`cargo test`) |
| `reference/go` | **ok** (cached, all packages green) |
| `reference/elixir` | **29 tests, 0 failures** (`mix test`) |
| `reference/typescript` | **Not run — pre-existing env breakage** unrelated to the rename: `node_modules/vitest/dist/cli-wrapper.js` missing on disk; `dist/` directory does not exist. The TS impl could be silently broken; tracking as a separate follow-up PR. |

## Out of scope
- No git tag created or moved (release-policy decision).
- A separate follow-up PR will fix the unrelated `reference/typescript` lockfile drift (`package.json: 1.0.1` vs `package-lock.json: 1.0.0`) and the broken `node_modules/vitest` install.

## Test plan
- [x] Validator runs clean on all v1.2 typed fixtures
- [x] Python / Rust / Go / Elixir reference suites pass
- [ ] TypeScript reference suite (separate follow-up PR)
- [x] No remaining `*-draft` references to renamed files in main tree