### PR TITLE
docs(spec): credit Jonathan Conway and drop "LLC" from company name

### DIFF
--- a/spec/proposals/2026-05-07-permissioned-memory-v1.3.md
+++ b/spec/proposals/2026-05-07-permissioned-memory-v1.3.md
@@ -3,7 +3,7 @@
 **Status:** Proposal draft, now superseded by `spec/v1.3/oamp-v1.3-draft.md`
 **Target version:** v1.3 (additive over v1.0 / v1.1 / v1.2)
 **Date:** 2026-05-07
-**Authors:** Deep Thinking LLC
+**Authors:** Jonathan Conway (Deep Thinking)
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 **Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1.md`, `spec/v1.2/oamp-v1.2.md`, `spec/v1.2/oamp-v1.2-governed-memory.md`
 **Related:** `spec/v2.0/oamp-v2.0-withheld-results-rfc.md`

--- a/spec/v1.1/oamp-v1.1.md
+++ b/spec/v1.1/oamp-v1.1.md
@@ -2,7 +2,7 @@
 
 **Status:** Stable
 **Date:** 2026-05-09
-**Authors:** Deep Thinking LLC
+**Authors:** Jonathan Conway (Deep Thinking)
 **Supersedes:** None — extends v1.0.0 additively
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 

--- a/spec/v1.2/oamp-v1.2-governed-memory.md
+++ b/spec/v1.2/oamp-v1.2-governed-memory.md
@@ -2,7 +2,7 @@
 
 **Status:** Stable
 **Date:** 2026-05-09
-**Authors:** Deep Thinking LLC
+**Authors:** Jonathan Conway (Deep Thinking)
 **Related implementations:** `cosmictron`, `kizuna-mem`, `ultra`, `toraeru`
 **Depends on:** `spec/v1/oamp-v1.md`, `spec/v1.1/oamp-v1.1.md`
 

--- a/spec/v1.2/oamp-v1.2.md
+++ b/spec/v1.2/oamp-v1.2.md
@@ -2,7 +2,7 @@
 
 **Status:** Stable  
 **Date:** 2026-05-09  
-**Authors:** Deep Thinking LLC  
+**Authors:** Jonathan Conway (Deep Thinking)  
 **Supersedes:** None — extends v1.0.0 and v1.1.0 additively  
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 

--- a/spec/v1.3/oamp-v1.3-draft.md
+++ b/spec/v1.3/oamp-v1.3-draft.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft (proposed minor version)  
 **Date:** 2026-05-07  
-**Authors:** Deep Thinking LLC  
+**Authors:** Jonathan Conway (Deep Thinking)  
 **Supersedes:** None — extends v1.0.0, v1.1.0, and v1.2.0 additively  
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 

--- a/spec/v1/oamp-v1.ja.md
+++ b/spec/v1/oamp-v1.ja.md
@@ -2,7 +2,7 @@
 
 **ステータス:** 草案  
 **日付:** 2026-04-06  
-**著者:** Deep Thinking LLC  
+**著者:** Jonathan Conway (Deep Thinking)  
 **リポジトリ:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 
 ---

--- a/spec/v1/oamp-v1.ko.md
+++ b/spec/v1/oamp-v1.ko.md
@@ -2,7 +2,7 @@
 
 **상태:** 초안  
 **날짜:** 2026-04-06  
-**저자:** Deep Thinking LLC  
+**저자:** Jonathan Conway (Deep Thinking)  
 **저장소:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 
 ---

--- a/spec/v1/oamp-v1.md
+++ b/spec/v1/oamp-v1.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Date:** 2026-04-06
-**Authors:** Deep Thinking
+**Authors:** Jonathan Conway (Deep Thinking)
 **Repository:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 
 ---

--- a/spec/v1/oamp-v1.ms.md
+++ b/spec/v1/oamp-v1.ms.md
@@ -2,7 +2,7 @@
 
 **Status:** Draf  
 **Tarikh:** 2026-04-06  
-**Pengarang:** Deep Thinking LLC  
+**Pengarang:** Jonathan Conway (Deep Thinking)  
 **Repositori:** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 
 ---

--- a/spec/v1/oamp-v1.zh.md
+++ b/spec/v1/oamp-v1.zh.md
@@ -2,7 +2,7 @@
 
 **状态：** 草案  
 **日期：** 2026-04-06  
-**作者：** Deep Thinking LLC  
+**作者：** Jonathan Conway (Deep Thinking)  
 **仓库：** `github.com/deep-thinking-llc/open-agent-memory-protocol`
 
 ---

--- a/spec/v2.0/oamp-v2.0-withheld-results-rfc.md
+++ b/spec/v2.0/oamp-v2.0-withheld-results-rfc.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft RFC seed  
 **Date:** 2026-05-07  
-**Authors:** Deep Thinking LLC  
+**Authors:** Jonathan Conway (Deep Thinking)  
 **Related issue:** `#16`
 
 ---


### PR DESCRIPTION
## Summary

Updates author lines across all spec files to:

> Jonathan Conway (Deep Thinking)

Replaces the prior `Deep Thinking LLC` form (which mislabelled the legal entity) and adds the individual author by name. RFC-style author + affiliation, consistent across all locales.

## Files changed (11)

| File | Before | After |
|---|---|---|
| `spec/v1/oamp-v1.md` | `**Authors:** Deep Thinking` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/v1/oamp-v1.ja.md` | `**著者:** Deep Thinking LLC` | `**著者:** Jonathan Conway (Deep Thinking)` |
| `spec/v1/oamp-v1.ko.md` | `**저자:** Deep Thinking LLC` | `**저자:** Jonathan Conway (Deep Thinking)` |
| `spec/v1/oamp-v1.zh.md` | `**作者：** Deep Thinking LLC` | `**作者：** Jonathan Conway (Deep Thinking)` |
| `spec/v1/oamp-v1.ms.md` | `**Pengarang:** Deep Thinking LLC` | `**Pengarang:** Jonathan Conway (Deep Thinking)` |
| `spec/v1.1/oamp-v1.1.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/v1.2/oamp-v1.2.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/v1.2/oamp-v1.2-governed-memory.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/v1.3/oamp-v1.3-draft.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/v2.0/oamp-v2.0-withheld-results-rfc.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |
| `spec/proposals/2026-05-07-permissioned-memory-v1.3.md` | `**Authors:** Deep Thinking LLC` | `**Authors:** Jonathan Conway (Deep Thinking)` |

## What's deliberately NOT changed

The `deep-thinking-llc/` GitHub org slug appears in 47 places across the repo (URLs in CHANGELOG, READMEs, package metadata, Cargo.toml, release workflow, generated protobuf code). **Left untouched** — it's a URL identifier, not a human-facing company name. Renaming the GitHub org would break every cross-reference, every npm scope, every clone URL, and is well outside the scope of "update the authors section."

If a full org rename is wanted later, that's a coordinated cross-repo migration (rename the GitHub org → npm scope → all package metadata → all docs) and should be its own dedicated piece of work.

## Verification

- `grep -r "Deep Thinking LLC\|Deep Thinking LTD\|Deep Thinking Ltd"` excluding `deep-thinking-llc/` URL slug → **zero matches** in main tree.
- All 11 files show the new author line.
- 11 files changed, +11/−11 lines.

## Test plan
- [x] Author lines updated in every spec file (English + 4 translations + v2.0 RFC + proposals)
- [x] No remaining `Deep Thinking LLC` strings outside the GitHub org slug
- [ ] dthink.ai sync workflow next run (every 4h) will pick up the new author info on `/spec` page automatically