### PR TITLE
ci: point trigger-site-sync at deep-thinking-llc/dthink.ai

### DIFF
--- a/.github/workflows/trigger-site-sync.yml
+++ b/.github/workflows/trigger-site-sync.yml
@@ -17,5 +17,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.DTHINK_SITE_PAT }}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/jaikoo/dthink.ai/dispatches \
+            https://api.github.com/repos/deep-thinking-llc/dthink.ai/dispatches \
             -d '{"event_type":"oamp-spec-updated"}'


### PR DESCRIPTION
## Summary

The `dthink.ai` repo was transferred from `jaikoo/` to `deep-thinking-llc/` on 2026-05-10. GitHub redirects most repo URLs automatically but the `repository_dispatch` API endpoint is not always covered by redirect rules.

This PR updates the hardcoded API URL in `trigger-site-sync.yml` from `jaikoo/dthink.ai` to `deep-thinking-llc/dthink.ai`. One-line change.

## Note on `DTHINK_SITE_PAT`

The PAT used by this workflow was scoped to `jaikoo/*`. After the transfer it may have lost permissions on the new owner. Test path:

1. Merge this PR.
2. Manually fire any workflow that pushes a spec file change (or run `workflow_dispatch` on `auto-translate-spec.yml`).
3. Watch the `Trigger Site Sync` job. If it 404s or 403s on the curl, the PAT needs regeneration with access to `deep-thinking-llc/dthink.ai`.

## Test plan
- [x] Single-line URL update
- [ ] After merge: confirm spec changes still trigger the dthink.ai cross-repo sync