### PR TITLE
ci: target kizuna stage Linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
   test-rust:
     name: Rust
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   test-typescript:
     name: TypeScript
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   test-python:
     name: Python ${{ matrix.python-version }}
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     strategy:
@@ -119,7 +119,7 @@ jobs:
 
   test-go:
     name: Go
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     steps:
@@ -150,7 +150,7 @@ jobs:
 
   test-elixir:
     name: Elixir
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     steps:
@@ -186,7 +186,7 @@ jobs:
 
   test-server:
     name: Reference Server
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 15
 
     steps:
@@ -224,7 +224,7 @@ jobs:
 
   interop-canary:
     name: Interop canary (reference server self-loopback)
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     needs: [test-server]
     timeout-minutes: 10
 
@@ -306,7 +306,7 @@ jobs:
 
   cross-language-check:
     name: Cross-language consistency
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     # Only require what reliably runs on this runner today. The TS/Go/Elixir/
     # Python-matrix jobs fail on toolchain or setup-python issues that need
     # runner-side fixes; including them here would skip this check on every

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   test:
     name: Run tests before release
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
   publish-rust:
     name: Publish Rust crate
     needs: test
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -89,7 +89,7 @@ jobs:
   publish-npm:
     name: Publish npm package
     needs: test
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -114,7 +114,7 @@ jobs:
   publish-pypi:
     name: Publish Python package
     needs: test
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -142,7 +142,7 @@ jobs:
   publish-elixir:
     name: Publish Elixir package
     needs: test
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -161,7 +161,7 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     needs: test
-    runs-on: [self-hosted, Linux, build-hetzner]
+    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Updates self-hosted Linux workflow jobs from the legacy build-hetzner labels to the org-level kizuna-stage-1 label.\n\nVerification:\n- Parsed all workflow YAML files locally.\n- Confirmed no legacy build-hetzner/linux-kvm runs-on selectors remain in workflows touched by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configurations to enhance build and release pipeline operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deep-thinking-lab/open-agent-memory-protocol/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->