### PR TITLE
proposals: v1.3.1 grant issuer/mediation + factory provenance

### DIFF
--- a/spec/proposals/2026-05-31-factory-provenance-context-v1.3.1.md
+++ b/spec/proposals/2026-05-31-factory-provenance-context-v1.3.1.md
@@ -1,0 +1,150 @@
+# Proposal: OAMP Factory / Delegated Provenance Context (v1.3.1)
+
+**Status:** Proposal draft
+**Target version:** v1.3.1 (additive over v1.0 / v1.1 / v1.2 / v1.3)
+**Date:** 2026-05-31
+**Authors:** Jonathan Conway (Deep Thinking)
+**Repository:** `github.com/deep-thinking-lab/open-agent-memory-protocol`
+**Depends on:** `spec/v1.3/oamp-v1.3-draft.md` (§4.1 claims, §4.3 provenance binding)
+**Related:** `spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md`
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+---
+
+## Abstract
+
+OAMP v1.3 §4.3 binds a write to the calling agent via
+`entry.source.agent_id == oamp_agent_id`. That is sufficient when the agent is a
+stable, standalone identity. It is **not** sufficient for **delegated, ephemeral
+agents** that act on behalf of a larger unit of work and exist only for the
+duration of that work.
+
+This proposal adds OPTIONAL grant claims that carry the **delegation context** of
+such an agent — the task it was spawned for, and any grouping above that task —
+and a SHOULD that the backend stamp this context onto written entries so
+knowledge remains attributable to the originating work, not just to an ephemeral
+agent id that no longer exists. All additions are backward-compatible.
+
+## 1. Motivation
+
+A common governed pattern: a planner decomposes a goal into tasks; each task is
+executed by a short-lived agent provisioned for it; the agent is revoked when
+the task ends. Knowledge those agents write outlives them.
+
+Binding such a write to `oamp_agent_id` alone is weak provenance:
+
+- the agent id is **ephemeral** — after revocation it resolves to nothing;
+- it loses the **delegation chain** — which task, and which grouping of tasks,
+  produced the knowledge;
+- it prevents useful queries like "show everything learned during task X."
+
+The originating context (`task`, and an optional parent grouping) is known at
+grant-issuance time. Carrying it on the grant lets the backend record durable,
+queryable provenance without inventing a parallel side-channel.
+
+## 2. Non-goals
+
+- This proposal does not define the *semantics* of the grouping above a task
+  (campaign, mission, session, run — deployment's choice). It standardizes only
+  the **carriage** of opaque identifiers.
+- It does not change read filtering or sensitivity semantics.
+- It does not require backends to index by these fields (a SHOULD, not a MUST,
+  for queryability).
+
+## 3. Grant claim additions (§4.1 delta)
+
+The following OPTIONAL claims extend the v1.3 §4.1 grant claim set:
+
+| Claim | Requirement | Description |
+|-------|-------------|-------------|
+| `oamp_task_id` | MAY | Identifier of the unit of work the agent was provisioned to perform. |
+| `oamp_context_id` | MAY | Identifier of an OPTIONAL grouping above the task (campaign / mission / run). Opaque to OAMP. |
+
+Both are opaque strings. They carry the delegation context; they do **not**
+grant any additional read/write authority (labels and sensitivity remain the
+sole authority claims, per v1.3 §4–§5).
+
+> Deployments MAY use additional vendor-prefixed claims for richer context
+> (e.g. `oamp_x_cell_id`). Only `oamp_task_id` and `oamp_context_id` are
+> standardized here.
+
+## 4. Write-time provenance stamping (§4.3 delta)
+
+When a write occurs under a grant carrying these claims, a v1.3.1 backend
+SHOULD record them in the entry's provenance so attribution survives the agent:
+
+```json
+{
+  "source": { "agent_id": "cell-agent-42" },
+  "provenance": {
+    "sources": [
+      {
+        "agent_id": "cell-agent-42",
+        "task_id": "task-7",
+        "context_id": "mission-3"
+      }
+    ]
+  }
+}
+```
+
+- The backend SHOULD copy `oamp_task_id` → `provenance.sources[*].task_id` and
+  `oamp_context_id` → `provenance.sources[*].context_id` for the entry written
+  under that grant.
+- The existing §4.3 binding is unchanged: the backend MUST still verify
+  `entry.source.agent_id == oamp_agent_id` when `source.agent_id` is present.
+- `task_id` / `context_id` on `provenance.sources[*]` are descriptive
+  attribution, not authority; backends MUST NOT use them to widen access.
+
+## 5. Queryability (optional)
+
+A backend MAY support filtering reads by `task_id` / `context_id` (subject to the
+normal v1.3 §5.1 read grant — provenance filters narrow, they never widen).
+Backends that support it SHOULD advertise it in capabilities (v1.3 §6):
+
+```json
+{ "governance": { "provenance_query": ["task_id", "context_id"] } }
+```
+
+## 6. Reference type additions
+
+The `oamp-types` reference libraries SHOULD add the OPTIONAL `task_id` and
+`context_id` fields to the provenance source shape so the additive
+factory-provenance carriage round-trips. This mirrors how v1.2/v1.3 governance
+metadata is already parsed additively.
+
+## 7. Backwards compatibility
+
+- **v1.3.0 backends:** ignore the new claims; provenance is recorded as today
+  (agent_id only). Safe.
+- **v1.0–v1.2 clients:** unaffected; the claims are optional and additive.
+- **Entries written without the claims:** unchanged shape — no `task_id` /
+  `context_id` keys appear.
+- Composes with the issuer/mediation proposal: a mediator that mints the grant
+  is the natural place to populate these context claims.
+
+## 8. Conformance summary
+
+A v1.3.1 backend that supports factory provenance SHOULD:
+
+- record `oamp_task_id` / `oamp_context_id` onto `provenance.sources[*]` on write;
+- preserve the v1.3 §4.3 `source.agent_id` binding;
+- treat the context fields as descriptive only (never authority-widening);
+- if it offers provenance queries, advertise `governance.provenance_query`.
+
+## 9. Open questions
+
+1. Flat claims (`oamp_task_id`, `oamp_context_id`) vs a single nested
+   `oamp_provenance` object. This draft chooses flat claims for JWT-friendliness.
+2. Whether `context_id` should allow a list (multi-level grouping) rather than a
+   single opaque id.
+3. Interaction with v2.0 provenance chains, if any.
+
+## References
+
+- `spec/v1.3/oamp-v1.3-draft.md` — §4.1 grant claims, §4.3 provenance binding, §6 capabilities
+- `spec/v1.2/oamp-v1.2.md` — governance metadata, provenance shape
+- Companion: `2026-05-31-grant-issuer-and-mediation-v1.3.1.md`

--- a/spec/proposals/2026-05-31-factory-provenance-context-v1.3.1.md
+++ b/spec/proposals/2026-05-31-factory-provenance-context-v1.3.1.md
@@ -78,10 +78,16 @@ SHOULD record them in the entry's provenance so attribution survives the agent:
 
 ```json
 {
-  "source": { "agent_id": "cell-agent-42" },
+  "source": {
+    "session_id": "sess-cell-42",
+    "timestamp": "2026-05-31T12:00:00Z",
+    "agent_id": "cell-agent-42"
+  },
   "provenance": {
     "sources": [
       {
+        "session_id": "sess-cell-42",
+        "timestamp": "2026-05-31T12:00:00Z",
         "agent_id": "cell-agent-42",
         "task_id": "task-7",
         "context_id": "mission-3"
@@ -90,6 +96,11 @@ SHOULD record them in the entry's provenance so attribution survives the agent:
   }
 }
 ```
+
+> `session_id` and `timestamp` are REQUIRED on both `source` and each
+> `provenance.sources[*]` entry by the v1.2/v1.3 `knowledge-entry` schema; they
+> are shown here so the example validates. `agent_id`, `task_id`, and
+> `context_id` are the additive fields.
 
 - The backend SHOULD copy `oamp_task_id` → `provenance.sources[*].task_id` and
   `oamp_context_id` → `provenance.sources[*].context_id` for the entry written
@@ -103,18 +114,39 @@ SHOULD record them in the entry's provenance so attribution survives the agent:
 
 A backend MAY support filtering reads by `task_id` / `context_id` (subject to the
 normal v1.3 §5.1 read grant — provenance filters narrow, they never widen).
-Backends that support it SHOULD advertise it in capabilities (v1.3 §6):
+Backends that support it SHOULD advertise it under the v1.3 governance
+enforcement block (v1.3 §6 — `capabilities.governance.enforcement`, with a
+top-level `oamp_version`):
 
 ```json
-{ "governance": { "provenance_query": ["task_id", "context_id"] } }
+{
+  "oamp_version": "1.3.1",
+  "capabilities": {
+    "governance": {
+      "enforcement": {
+        "provenance_query": ["task_id", "context_id"]
+      }
+    }
+  }
+}
 ```
 
-## 6. Reference type additions
+## 6. Required schema & reference-type updates
 
-The `oamp-types` reference libraries SHOULD add the OPTIONAL `task_id` and
-`context_id` fields to the provenance source shape so the additive
-factory-provenance carriage round-trips. This mirrors how v1.2/v1.3 governance
-metadata is already parsed additively.
+The v1.3 `knowledge-entry` schema defines `$defs.provenance_source` (and
+`source`) with **`additionalProperties: false`**, so `task_id` / `context_id`
+are rejected today. This proposal is therefore **not** purely descriptive — it
+requires, normative for v1.3.1:
+
+1. **JSON Schema:** add OPTIONAL `task_id` and `context_id` (string) to the
+   v1.3.1 `knowledge-entry` schema's `provenance_source` definition. Without
+   this, a writer following the §4 SHOULD emits a **schema-invalid** entry.
+2. **Reference types:** add the same OPTIONAL fields to the `oamp-types`
+   provenance-source shape (Rust/TS/Python/Go/Elixir) so the additive carriage
+   round-trips, mirroring how v1.2/v1.3 governance metadata is parsed additively.
+
+`session_id` / `timestamp` remain REQUIRED on `provenance_source`; the new
+fields are additive and OPTIONAL.
 
 ## 7. Backwards compatibility
 

--- a/spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md
+++ b/spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md
@@ -25,9 +25,10 @@ This proposal adds the **mediated** model: a grant is minted by a **trusted
 issuer** (a mediator that sits between agent and backend), and the backend is
 configured to **reject grants that do not originate from a trusted issuer** when
 a resource requires mediation. It introduces one standard claim (`iss`), one
-optional claim (`oamp_mediation_required`), an entry-level `handling` value
-(`mediated`), a trusted-issuer backend configuration, and the enforcement and
-capability rules that bind them. All additions are backward-compatible.
+optional claim (`oamp_mediation_required`), an entry-level
+`governance.handling.mediation` property (with a matching v1.3.1 schema update),
+a trusted-issuer backend configuration, and the enforcement and capability rules
+that bind them. All additions are backward-compatible.
 
 ## 1. Motivation
 
@@ -64,7 +65,7 @@ proposal closes that gap.
 
 | Claim | Requirement | Description |
 |-------|-------------|-------------|
-| `iss` | MUST when mediation is required; otherwise MAY | Stable identifier of the authority that minted the grant. Matches a key entry in the backend's trusted-issuer set. |
+| `iss` | MUST when the grant is issued for mediation-required resources; otherwise MAY | Stable identifier of the authority that minted the grant. Matches a key entry in the backend's trusted-issuer set. The issuer (mediator) is responsible for including it; the backend never has to infer mediation before validating `iss`. |
 
 `iss` reuses the registered JWT `iss` claim ([RFC 7519] §4.1.1). When the grant
 is conveyed as the `OAMP-Grant` compact JWS (v1.3 §4.2), `iss` is a claim in the
@@ -85,21 +86,23 @@ A v1.3.1 backend MAY be configured with a **trusted-issuer set**: a mapping from
 **support mediation**.
 
 A backend MUST verify the grant's signature against the key registered for the
-grant's `iss`. A grant whose `iss` is absent from the set, or whose signature
-does not verify under that issuer's key, is **untrusted**.
+grant's `iss`. A grant is **untrusted** if it lacks an `iss` claim, if its `iss`
+value is not in the trusted-issuer set, or if its signature does not verify
+under that issuer's registered key.
 
 ## 5. Enforcement (normative)
 
 A resource is **mediation-required** if the backend's policy marks it so (for
-example, an entry whose `governance.handling` includes `mediated` — §6 — or a
-backend operating in mediation-only mode).
+example, an entry whose `governance.handling.mediation` is `required` — §6 — or
+a backend operating in mediation-only mode).
 
 For a mediation-required resource, in addition to the v1.3 §5 rules, the backend
 MUST:
 
-1. **Reject untrusted grants.** If the grant's `iss` is absent from the
-   trusted-issuer set, or its signature does not verify under that issuer's key,
-   the request MUST be treated as having **no valid grant**.
+1. **Reject untrusted grants.** If the grant lacks an `iss` claim, or its `iss`
+   value is not in the trusted-issuer set, or its signature does not verify
+   under that issuer's key, the request MUST be treated as having **no valid
+   grant**.
 2. **Preserve existence hiding** (v1.3 §5.2). On read surfaces, a request with
    no valid grant MUST yield `404 Not Found` for in-scope-by-content but
    unmediated access — never `403` that reveals existence. On write surfaces,
@@ -110,27 +113,49 @@ MUST:
 A backend that does **not** support mediation (empty trusted-issuer set) ignores
 `iss` and behaves exactly as v1.3.
 
-## 6. `governance.handling` addition: `mediated`
+## 6. `governance.handling.mediation` addition
 
-This proposal adds an OPTIONAL `mediated` token to the entry-level
-`governance.handling` set (v1.2 §3.1 / v1.3 §3.3). An entry tagged
-`handling: ["mediated"]` is a mediation-required resource per §5: it MUST NOT be
-read, written, exported, or streamed except under a grant from a trusted issuer.
+`governance.handling` is an **object** of surface hints — `retrieval`, `export`,
+`stream`, each `"governed" | "ungoverned"` — and the v1.3 `knowledge-entry`
+schema closes it with `additionalProperties: false` (v1.3 §3.3). This proposal
+adds an OPTIONAL `mediation` property to that object:
 
-Backends that do not support mediation MUST ignore the `mediated` token (it is
+```json
+{ "governance": { "handling": { "mediation": "required" } } }
+```
+
+| Property | Type | Values | Meaning |
+|----------|------|--------|---------|
+| `governance.handling.mediation` | string | `"required"` \| `"optional"` | `required`: the entry is a mediation-required resource per §5 (no read/write/export/stream except under a trusted-issuer grant). `optional` (default when absent): no mediation constraint. |
+
+**Required schema update (normative for v1.3.1):** because v1.3 closes
+`handling` with `additionalProperties: false`, conformance requires the v1.3.1
+`knowledge-entry` JSON Schema (and `oamp-types`) to add the `mediation` property
+to the `handling` object. Without that schema bump, a `mediation` hint is
+schema-invalid — implementers MUST ship the schema change alongside this draft.
+
+Backends that do not support mediation MUST ignore the `mediation` hint (it is
 descriptive, per the v1.2 handling model), which preserves compatibility.
 
 ## 7. Capabilities advertisement
 
-A v1.3.1 backend that supports mediation SHOULD advertise it in the capabilities
-document (v1.3 §6):
+A v1.3.1 backend that supports mediation SHOULD advertise it under the v1.3
+governance enforcement block (v1.3 §6 — `capabilities.governance.enforcement`,
+with a top-level `oamp_version`):
 
 ```json
 {
-  "governance": {
-    "mediation": {
-      "supported": true,
-      "trusted_issuers": ["ultra"]
+  "oamp_version": "1.3.1",
+  "capabilities": {
+    "governance": {
+      "enforcement": {
+        "supported": true,
+        "spec_version": "1.3.1",
+        "mediation": {
+          "supported": true,
+          "trusted_issuers": ["ultra"]
+        }
+      }
     }
   }
 }
@@ -154,14 +179,16 @@ document (v1.3 §6):
 
 ## 9. Backwards compatibility
 
-- **v1.3.0 backends:** ignore `iss` / `mediated` and enforce as before. Safe.
+- **v1.3.0 backends:** ignore `iss` and the `handling.mediation` hint and
+  enforce as before. Safe.
 - **v1.0–v1.2 clients:** unaffected; they neither send `iss` nor target
   mediation-required resources (which are advertised via capabilities).
 - **Grants without `iss`:** accepted by non-mediating backends; treated as
   untrusted (no valid grant) only by backends enforcing mediation on the
   targeted resource.
-- The `mediated` handling token is additive to an open string set and is ignored
-  where unsupported.
+- **`handling.mediation`** is an additive OPTIONAL property on the `handling`
+  object and requires the v1.3.1 schema bump (§6); backends that don't support
+  mediation ignore it.
 
 ## 10. Conformance summary
 

--- a/spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md
+++ b/spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md
@@ -1,0 +1,189 @@
+# Proposal: OAMP Grant Issuer Binding & Mediation Requirement (v1.3.1)
+
+**Status:** Proposal draft
+**Target version:** v1.3.1 (additive over v1.0 / v1.1 / v1.2 / v1.3)
+**Date:** 2026-05-31
+**Authors:** Jonathan Conway (Deep Thinking)
+**Repository:** `github.com/deep-thinking-lab/open-agent-memory-protocol`
+**Depends on:** `spec/v1.3/oamp-v1.3-draft.md` (§4 grant claims, §5 enforcement)
+**Related:** `spec/proposals/2026-05-07-permissioned-memory-v1.3.md`
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+---
+
+## Abstract
+
+OAMP v1.3 (§4) defines agent **grant claims** carried in a JWT or the
+`OAMP-Grant` header, and (§5) the backend enforcement rules that apply them.
+v1.3 assumes a **two-party** model: the calling agent presents its own grant
+directly to the backend.
+
+This proposal adds the **mediated** model: a grant is minted by a **trusted
+issuer** (a mediator that sits between agent and backend), and the backend is
+configured to **reject grants that do not originate from a trusted issuer** when
+a resource requires mediation. It introduces one standard claim (`iss`), one
+optional claim (`oamp_mediation_required`), an entry-level `handling` value
+(`mediated`), a trusted-issuer backend configuration, and the enforcement and
+capability rules that bind them. All additions are backward-compatible.
+
+## 1. Motivation
+
+In governed multi-agent platforms the agent is frequently **not trusted to
+self-assert its own grant**. A separate authority evaluates policy, scopes the
+grant, and signs it; the memory backend must be able to prove the grant came
+from that authority and refuse anything else.
+
+Concretely (the motivating deployment): ephemeral worker agents run inside
+isolated cells. A central governor mints a scoped, signed grant per cell and
+proxies the agent's memory access. The memory backend must:
+
+1. accept grants **only** from the governor's signing key(s), and
+2. **reject** a grant presented directly by a cell (self-issued, or issued by an
+   untrusted party), for resources marked as requiring mediation.
+
+v1.3 cannot express this: it has no notion of *who issued* a grant, nor any way
+to require mediation. The grant is simply a bearer object the agent holds. This
+proposal closes that gap.
+
+## 2. Non-goals
+
+- This proposal does **not** define the mediator's internal policy engine, nor
+  how it decides a grant's labels/sensitivity. That is deployment-specific.
+- It does **not** mandate a particular PKI, key-distribution, or rotation
+  mechanism. It specifies only that the backend holds a set of trusted issuer
+  keys and how it uses them.
+- It does **not** change the v1.3 claim semantics for read/write labels or
+  sensitivity; it composes with them.
+
+## 3. Grant claim additions
+
+### 3.1 `iss` (issuer)
+
+| Claim | Requirement | Description |
+|-------|-------------|-------------|
+| `iss` | MUST when mediation is required; otherwise MAY | Stable identifier of the authority that minted the grant. Matches a key entry in the backend's trusted-issuer set. |
+
+`iss` reuses the registered JWT `iss` claim ([RFC 7519] §4.1.1). When the grant
+is conveyed as the `OAMP-Grant` compact JWS (v1.3 §4.2), `iss` is a claim in the
+JWS payload and the JWS signature MUST verify against the key registered for
+that issuer.
+
+### 3.2 `oamp_mediation_required`
+
+| Claim | Requirement | Description |
+|-------|-------------|-------------|
+| `oamp_mediation_required` | MAY | When `true`, signals that this grant is intended for a mediated flow. Informational for clients; backends rely on their own resource policy (§5), not solely on this flag. |
+
+## 4. Backend configuration: trusted-issuer set
+
+A v1.3.1 backend MAY be configured with a **trusted-issuer set**: a mapping from
+`iss` value to one or more verifying keys and the permitted signature algorithm
+(e.g. `EdDSA`). A backend with a non-empty trusted-issuer set is said to
+**support mediation**.
+
+A backend MUST verify the grant's signature against the key registered for the
+grant's `iss`. A grant whose `iss` is absent from the set, or whose signature
+does not verify under that issuer's key, is **untrusted**.
+
+## 5. Enforcement (normative)
+
+A resource is **mediation-required** if the backend's policy marks it so (for
+example, an entry whose `governance.handling` includes `mediated` — §6 — or a
+backend operating in mediation-only mode).
+
+For a mediation-required resource, in addition to the v1.3 §5 rules, the backend
+MUST:
+
+1. **Reject untrusted grants.** If the grant's `iss` is absent from the
+   trusted-issuer set, or its signature does not verify under that issuer's key,
+   the request MUST be treated as having **no valid grant**.
+2. **Preserve existence hiding** (v1.3 §5.2). On read surfaces, a request with
+   no valid grant MUST yield `404 Not Found` for in-scope-by-content but
+   unmediated access — never `403` that reveals existence. On write surfaces,
+   rejection is `403 Forbidden` (consistent with v1.3 §5.3).
+3. Apply this across all enforced surfaces: read (§5.1), existence (§5.2), write
+   (§5.3), import (§5.4), export (§5.5), and stream (§5.6).
+
+A backend that does **not** support mediation (empty trusted-issuer set) ignores
+`iss` and behaves exactly as v1.3.
+
+## 6. `governance.handling` addition: `mediated`
+
+This proposal adds an OPTIONAL `mediated` token to the entry-level
+`governance.handling` set (v1.2 §3.1 / v1.3 §3.3). An entry tagged
+`handling: ["mediated"]` is a mediation-required resource per §5: it MUST NOT be
+read, written, exported, or streamed except under a grant from a trusted issuer.
+
+Backends that do not support mediation MUST ignore the `mediated` token (it is
+descriptive, per the v1.2 handling model), which preserves compatibility.
+
+## 7. Capabilities advertisement
+
+A v1.3.1 backend that supports mediation SHOULD advertise it in the capabilities
+document (v1.3 §6):
+
+```json
+{
+  "governance": {
+    "mediation": {
+      "supported": true,
+      "trusted_issuers": ["ultra"]
+    }
+  }
+}
+```
+
+`trusted_issuers` lists issuer identifiers only — never key material.
+
+## 8. Worked example (non-normative)
+
+1. A governor (`iss: "ultra"`) evaluates policy for an ephemeral cell agent and
+   mints an `OAMP-Grant` compact JWS: `iss=ultra`, `oamp_agent_id=cell-agent-42`,
+   `oamp_read_labels=["project/*"]`, `oamp_sensitivity_max=confidential`,
+   `exp=…`. It signs with its EdDSA key and proxies the agent's recall to the
+   backend, attaching the header.
+2. The backend (trusted-issuer set `{ultra → <key>}`) verifies the JWS against
+   the `ultra` key, accepts the grant, and applies §5.1 read filtering.
+3. A compromised cell instead contacts the backend **directly** with a grant it
+   minted itself (`iss=cell-agent-42`). The backend finds `cell-agent-42` is not
+   in its trusted-issuer set → no valid grant → `404` on the read surface. The
+   cell cannot escalate by self-issuing.
+
+## 9. Backwards compatibility
+
+- **v1.3.0 backends:** ignore `iss` / `mediated` and enforce as before. Safe.
+- **v1.0–v1.2 clients:** unaffected; they neither send `iss` nor target
+  mediation-required resources (which are advertised via capabilities).
+- **Grants without `iss`:** accepted by non-mediating backends; treated as
+  untrusted (no valid grant) only by backends enforcing mediation on the
+  targeted resource.
+- The `mediated` handling token is additive to an open string set and is ignored
+  where unsupported.
+
+## 10. Conformance summary
+
+A v1.3.1 backend claiming **mediation support** MUST:
+
+- maintain a trusted-issuer set and verify grant signatures against it;
+- treat grants with absent/untrusted `iss` as having no valid grant on
+  mediation-required resources;
+- preserve v1.3 §5 enforcement and existence-hiding semantics;
+- advertise `governance.mediation` in capabilities.
+
+## 11. Open questions
+
+1. Should `iss` be REQUIRED on *all* v1.3.1 grants (simpler) or only when
+   mediation is required (less disruptive)? This draft chooses the latter.
+2. Multiple acceptable issuers per resource vs a single backend-wide set.
+3. Key rotation: overlap window for an issuer's old/new verifying keys.
+
+## References
+
+- `spec/v1.3/oamp-v1.3-draft.md` — §4 grant claims, §5 enforcement, §6 capabilities
+- `spec/v1.2/oamp-v1.2.md` — §3 governance metadata, `handling`
+- [RFC 7519](https://www.rfc-editor.org/rfc/rfc7519) — JSON Web Token (`iss`)
+- [RFC 7515](https://www.rfc-editor.org/rfc/rfc7515) — JSON Web Signature (compact JWS)
+- Companion: `2026-05-31-factory-provenance-context-v1.3.1.md`


### PR DESCRIPTION
Two additive **v1.3.1** proposals for governed multi-agent (factory) deployments where ephemeral worker agents reach memory through a trusted mediator.

### 1. Grant issuer binding & mediation requirement
`spec/proposals/2026-05-31-grant-issuer-and-mediation-v1.3.1.md`

v1.3 assumes a two-party model (agent presents its own grant). This adds the **mediated** model:
- `iss` claim + a backend **trusted-issuer set** (issuer → verifying key)
- `oamp_mediation_required` claim and a `governance.handling: "mediated"` value
- Enforcement: a mediation-required resource MUST reject grants whose `iss` is absent/untrusted, preserving v1.3 §5 existence-hiding (404 on read). A self-issued grant from a compromised agent can't escalate.

### 2. Factory / delegated provenance context
`spec/proposals/2026-05-31-factory-provenance-context-v1.3.1.md`

§4.3 binds writes to `agent_id` only — too weak for ephemeral delegated agents. This adds OPTIONAL `oamp_task_id` / `oamp_context_id` grant claims and a SHOULD that backends stamp them onto `provenance.sources[*]`, so knowledge stays attributable to the originating work after the agent is revoked. Descriptive only — never authority-widening.

Both additive and backward-compatible over v1.0–v1.3; same format as `2026-05-07-permissioned-memory-v1.3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OAMP v1.3.1 proposal for factory/spawned-agent provenance: optional task/context identifiers, optional read-filtering by those ids, and a governance capability for provenance queries; documents compatibility and conformance.
  * Added OAMP v1.3.1 proposal for issuer-bound grants and mediation: introduces issuer claims and mediation handling hints, capability advertisement for trusted issuers, compatibility guidance, examples, and conformance checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->