### PR TITLE
[codex] Implement OAMP v1.3.1 additive fields

### DIFF
--- a/reference/elixir/lib/oamp_types/knowledge.ex
+++ b/reference/elixir/lib/oamp_types/knowledge.ex
@@ -37,12 +37,13 @@ defmodule OampTypes.Knowledge do
     @moduledoc """
     Surface-specific handling hints for governed memory.
     """
-    defstruct [:retrieval, :export, :stream]
+    defstruct [:retrieval, :export, :stream, :mediation]
 
     @type t :: %__MODULE__{
       retrieval: String.t() | nil,
       export: String.t() | nil,
-      stream: String.t() | nil
+      stream: String.t() | nil,
+      mediation: String.t() | nil
     }
   end
 
@@ -65,13 +66,15 @@ defmodule OampTypes.Knowledge do
     Extended lineage record for multi-source provenance.
     """
     @enforce_keys [:session_id, :timestamp]
-    defstruct [:session_id, :agent_id, :timestamp, :turn_id]
+    defstruct [:session_id, :agent_id, :timestamp, :turn_id, :task_id, :context_id]
 
     @type t :: %__MODULE__{
       session_id: String.t(),
       agent_id: String.t() | nil,
       timestamp: String.t(),
-      turn_id: String.t() | nil
+      turn_id: String.t() | nil,
+      task_id: String.t() | nil,
+      context_id: String.t() | nil
     }
   end
 
@@ -201,7 +204,9 @@ defmodule OampTypes.Knowledge do
                     session_id: source["session_id"],
                     agent_id: source["agent_id"],
                     timestamp: source["timestamp"],
-                    turn_id: source["turn_id"]
+                    turn_id: source["turn_id"],
+                    task_id: source["task_id"],
+                    context_id: source["context_id"]
                   }
                 end)
             }
@@ -218,7 +223,8 @@ defmodule OampTypes.Knowledge do
                   %GovernanceHandling{
                     retrieval: h["retrieval"],
                     export: h["export"],
-                    stream: h["stream"]
+                    stream: h["stream"],
+                    mediation: h["mediation"]
                   }
               end
 
@@ -374,6 +380,7 @@ defmodule OampTypes.Knowledge do
       fields = if handling.retrieval, do: Map.put(fields, "retrieval", handling.retrieval), else: fields
       fields = if handling.export, do: Map.put(fields, "export", handling.export), else: fields
       fields = if handling.stream, do: Map.put(fields, "stream", handling.stream), else: fields
+      fields = if handling.mediation, do: Map.put(fields, "mediation", handling.mediation), else: fields
       Jason.Encode.map(fields, opts)
     end
   end
@@ -396,6 +403,8 @@ defmodule OampTypes.Knowledge do
 
       fields = if source.agent_id, do: Map.put(fields, "agent_id", source.agent_id), else: fields
       fields = if source.turn_id, do: Map.put(fields, "turn_id", source.turn_id), else: fields
+      fields = if source.task_id, do: Map.put(fields, "task_id", source.task_id), else: fields
+      fields = if source.context_id, do: Map.put(fields, "context_id", source.context_id), else: fields
       Jason.Encode.map(fields, opts)
     end
   end

--- a/reference/elixir/test/knowledge_test.exs
+++ b/reference/elixir/test/knowledge_test.exs
@@ -89,6 +89,53 @@ defmodule OampTypes.KnowledgeTest do
       assert decoded.governance.sensitivity_class == "internal"
       assert hd(decoded.provenance.sources).turn_id == "turn-1"
     end
+
+    test "encodes and decodes v1.3.1 mediation and factory provenance fields" do
+      entry = %Entry{
+        oamp_version: "1.3.1",
+        id: "8f6ec84e-17f5-4dc2-a8c3-f056d3124925",
+        user_id: "user-123",
+        category: :fact,
+        content: "Factory cell learned a mediated deployment preference.",
+        confidence: 0.86,
+        source: %Source{
+          session_id: "sess-cell-42",
+          agent_id: "cell-agent-42",
+          timestamp: "2026-05-31T12:00:00Z"
+        },
+        provenance: %Provenance{
+          sources: [
+            %ProvenanceSource{
+              session_id: "sess-cell-42",
+              agent_id: "cell-agent-42",
+              timestamp: "2026-05-31T12:00:00Z",
+              turn_id: "turn-7",
+              task_id: "task-7",
+              context_id: "mission-3"
+            }
+          ],
+          derived: false
+        },
+        governance: %Governance{
+          sensitivity_class: "confidential",
+          labels: ["work.deployment"],
+          handling: %GovernanceHandling{
+            retrieval: "governed",
+            export: "governed",
+            stream: "governed",
+            mediation: "required"
+          }
+        }
+      }
+
+      json = Entry.to_json(entry)
+      decoded = Entry.from_json(json)
+
+      assert decoded.oamp_version == "1.3.1"
+      assert decoded.governance.handling.mediation == "required"
+      assert hd(decoded.provenance.sources).task_id == "task-7"
+      assert hd(decoded.provenance.sources).context_id == "mission-3"
+    end
   end
 
   describe "spec example parsing" do

--- a/reference/go/knowledge.go
+++ b/reference/go/knowledge.go
@@ -38,6 +38,8 @@ type ProvenanceSource struct {
 	AgentID   *string   `json:"agent_id,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 	TurnID    *string   `json:"turn_id,omitempty"`
+	TaskID    *string   `json:"task_id,omitempty"`
+	ContextID *string   `json:"context_id,omitempty"`
 }
 
 type Provenance struct {
@@ -49,6 +51,7 @@ type GovernanceHandling struct {
 	Retrieval *string `json:"retrieval,omitempty"`
 	Export    *string `json:"export,omitempty"`
 	Stream    *string `json:"stream,omitempty"`
+	Mediation *string `json:"mediation,omitempty"`
 }
 
 type Governance struct {

--- a/reference/go/knowledge_test.go
+++ b/reference/go/knowledge_test.go
@@ -170,6 +170,75 @@ func TestGovernedKnowledgeEntryRoundTrip(t *testing.T) {
 	}
 }
 
+func TestV131MediationAndFactoryProvenanceRoundTrip(t *testing.T) {
+	retrieval := "governed"
+	export := "governed"
+	stream := "governed"
+	mediation := "required"
+	agentID := "cell-agent-42"
+	turnID := "turn-7"
+	taskID := "task-7"
+	contextID := "mission-3"
+	derived := false
+	entry := &KnowledgeEntry{
+		OAMPVersion: "1.3.1",
+		Type:        "knowledge_entry",
+		ID:          "8f6ec84e-17f5-4dc2-a8c3-f056d3124925",
+		UserID:      "user-123",
+		Category:    KnowledgeCategoryFact,
+		Content:     "Factory cell learned a mediated deployment preference.",
+		Confidence:  0.86,
+		Source: KnowledgeSource{
+			SessionID: "sess-cell-42",
+			AgentID:   &agentID,
+			Timestamp: parseTime("2026-05-31T12:00:00Z"),
+		},
+		Provenance: &Provenance{
+			Sources: []ProvenanceSource{
+				{
+					SessionID: "sess-cell-42",
+					AgentID:   &agentID,
+					Timestamp: parseTime("2026-05-31T12:00:00Z"),
+					TurnID:    &turnID,
+					TaskID:    &taskID,
+					ContextID: &contextID,
+				},
+			},
+			Derived: &derived,
+		},
+		Governance: &Governance{
+			SensitivityClass: "confidential",
+			Labels:           []string{"work.deployment"},
+			Handling: &GovernanceHandling{
+				Retrieval: &retrieval,
+				Export:    &export,
+				Stream:    &stream,
+				Mediation: &mediation,
+			},
+		},
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var parsed KnowledgeEntry
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if parsed.Governance == nil || parsed.Governance.Handling == nil || *parsed.Governance.Handling.Mediation != "required" {
+		t.Fatalf("mediation was not preserved")
+	}
+	if parsed.Provenance == nil || *parsed.Provenance.Sources[0].TaskID != "task-7" || *parsed.Provenance.Sources[0].ContextID != "mission-3" {
+		t.Fatalf("factory provenance context was not preserved")
+	}
+	if errors := ValidateKnowledgeEntry(&parsed); len(errors) != 0 {
+		t.Fatalf("ValidateKnowledgeEntry() errors = %v", errors)
+	}
+}
+
 func TestParseKnowledgeEntryExample(t *testing.T) {
 	data, err := os.ReadFile("../../spec/v1/examples/knowledge-entry.json")
 	if err != nil {

--- a/reference/go/validate.go
+++ b/reference/go/validate.go
@@ -10,7 +10,7 @@ import (
 var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`)
 
 func isSupportedKnowledgeVersion(version string) bool {
-	return version == "1.0.0" || version == "1.1.0" || version == "1.2.0" || version == "1.3.0"
+	return version == "1.0.0" || version == "1.1.0" || version == "1.2.0" || version == "1.3.0" || version == "1.3.1"
 }
 
 // ValidateKnowledgeEntry validates a KnowledgeEntry and returns a list of errors.
@@ -20,7 +20,7 @@ func ValidateKnowledgeEntry(e *KnowledgeEntry) []string {
 	if e.OAMPVersion == "" {
 		errors = append(errors, "oamp_version is required")
 	} else if !isSupportedKnowledgeVersion(e.OAMPVersion) {
-		errors = append(errors, fmt.Sprintf("oamp_version must be one of %q, %q, %q, or %q, got %q", "1.0.0", "1.1.0", "1.2.0", "1.3.0", e.OAMPVersion))
+		errors = append(errors, fmt.Sprintf("oamp_version must be one of %q, %q, %q, %q, or %q, got %q", "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1", e.OAMPVersion))
 	}
 
 	if e.Type != "knowledge_entry" {
@@ -74,7 +74,7 @@ func ValidateKnowledgeStore(s *KnowledgeStore) []string {
 	if s.OAMPVersion == "" {
 		errors = append(errors, "oamp_version is required")
 	} else if !isSupportedKnowledgeVersion(s.OAMPVersion) {
-		errors = append(errors, fmt.Sprintf("oamp_version must be one of %q, %q, %q, or %q, got %q", "1.0.0", "1.1.0", "1.2.0", "1.3.0", s.OAMPVersion))
+		errors = append(errors, fmt.Sprintf("oamp_version must be one of %q, %q, %q, %q, or %q, got %q", "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1", s.OAMPVersion))
 	}
 
 	if s.Type != "knowledge_store" {

--- a/reference/python/src/oamp_types/knowledge.py
+++ b/reference/python/src/oamp_types/knowledge.py
@@ -63,6 +63,7 @@ class GovernanceHandling(BaseModel):
     retrieval: Optional[Literal["governed", "ungoverned"]] = None
     export: Optional[Literal["governed", "ungoverned"]] = None
     stream: Optional[Literal["governed", "ungoverned"]] = None
+    mediation: Optional[Literal["required", "optional"]] = None
 
 
 class Governance(BaseModel):
@@ -84,6 +85,8 @@ class ProvenanceSource(BaseModel):
     timestamp: datetime
     agent_id: Optional[str] = None
     turn_id: Optional[str] = None
+    task_id: Optional[str] = None
+    context_id: Optional[str] = None
 
     @field_validator("session_id")
     @classmethod
@@ -131,8 +134,8 @@ class KnowledgeEntry(BaseModel):
     @field_validator("oamp_version")
     @classmethod
     def oamp_version_must_be_current(cls, v: str) -> str:
-        if v not in {"1.0.0", "1.1.0", "1.2.0", "1.3.0"}:
-            raise ValueError(f"oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', got '{v}'")
+        if v not in {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"}:
+            raise ValueError(f"oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', got '{v}'")
         return v
 
     @field_validator("type")
@@ -180,8 +183,8 @@ class KnowledgeStore(BaseModel):
     @field_validator("oamp_version")
     @classmethod
     def oamp_version_must_be_current(cls, v: str) -> str:
-        if v not in {"1.0.0", "1.1.0", "1.2.0", "1.3.0"}:
-            raise ValueError(f"oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', got '{v}'")
+        if v not in {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"}:
+            raise ValueError(f"oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', got '{v}'")
         return v
 
     @field_validator("type")

--- a/reference/python/src/oamp_types/validate.py
+++ b/reference/python/src/oamp_types/validate.py
@@ -16,7 +16,7 @@ import re
 from .knowledge import KnowledgeEntry, KnowledgeStore
 from .user_model import UserModel
 
-SUPPORTED_KNOWLEDGE_VERSIONS = {"1.0.0", "1.1.0", "1.2.0", "1.3.0"}
+SUPPORTED_KNOWLEDGE_VERSIONS = {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"}
 
 # Loose UUID v4 pattern for validation
 _UUID_RE = re.compile(
@@ -33,7 +33,7 @@ def validate_knowledge_entry(entry: KnowledgeEntry) -> list[str]:
         errors.append("oamp_version is required")
     elif entry.oamp_version not in SUPPORTED_KNOWLEDGE_VERSIONS:
         errors.append(
-            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', "
+            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', "
             f"got '{entry.oamp_version}'"
         )
 
@@ -71,7 +71,7 @@ def validate_knowledge_store(store: KnowledgeStore) -> list[str]:
         errors.append("oamp_version is required")
     elif store.oamp_version not in SUPPORTED_KNOWLEDGE_VERSIONS:
         errors.append(
-            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', "
+            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', "
             f"got '{store.oamp_version}'"
         )
 

--- a/reference/python/tests/test_oamp_types.py
+++ b/reference/python/tests/test_oamp_types.py
@@ -298,6 +298,49 @@ class TestKnowledgeEntrySerialization:
         assert parsed.governance.labels == ["finance", "ops"]
         assert parsed.provenance.sources[0].turn_id == "turn-2"
 
+    def test_roundtrip_preserves_v131_mediation_and_factory_provenance(self):
+        entry = KnowledgeEntry(
+            oamp_version="1.3.1",
+            user_id="user-1",
+            category=KnowledgeCategory.fact,
+            content="Factory cell learned a mediated deployment preference.",
+            confidence=0.86,
+            source=KnowledgeSource(
+                session_id="sess-cell-42",
+                agent_id="cell-agent-42",
+                timestamp=datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc),
+            ),
+            provenance=Provenance(
+                sources=[
+                    ProvenanceSource(
+                        session_id="sess-cell-42",
+                        timestamp=datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc),
+                        agent_id="cell-agent-42",
+                        turn_id="turn-7",
+                        task_id="task-7",
+                        context_id="mission-3",
+                    )
+                ],
+                derived=False,
+            ),
+            governance=Governance(
+                sensitivity_class="confidential",
+                labels=["work.deployment"],
+                handling=GovernanceHandling(
+                    retrieval="governed",
+                    export="governed",
+                    stream="governed",
+                    mediation="required",
+                ),
+            ),
+        )
+        parsed = KnowledgeEntry.model_validate_json(entry.model_dump_json(exclude_none=True))
+        assert parsed.oamp_version == "1.3.1"
+        assert parsed.governance.handling.mediation == "required"
+        assert parsed.provenance.sources[0].task_id == "task-7"
+        assert parsed.provenance.sources[0].context_id == "mission-3"
+        assert validate_knowledge_entry(parsed) == []
+
 
 class TestKnowledgeStore:
     """Tests for KnowledgeStore creation and serialization."""

--- a/reference/rust/src/knowledge.rs
+++ b/reference/rust/src/knowledge.rs
@@ -29,6 +29,10 @@ pub struct ProvenanceSource {
     pub agent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +49,13 @@ pub enum GovernanceHandlingMode {
     Ungoverned,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceMediationMode {
+    Required,
+    Optional,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GovernanceHandling {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,6 +64,8 @@ pub struct GovernanceHandling {
     pub export: Option<GovernanceHandlingMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<GovernanceHandlingMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mediation: Option<GovernanceMediationMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/reference/rust/src/validate.rs
+++ b/reference/rust/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::{KnowledgeEntry, KnowledgeStore, UserModel};
 
 fn is_supported_knowledge_version(version: &str) -> bool {
-    matches!(version, "1.0.0" | "1.1.0" | "1.2.0" | "1.3.0")
+    matches!(version, "1.0.0" | "1.1.0" | "1.2.0" | "1.3.0" | "1.3.1")
 }
 
 /// Validate a KnowledgeEntry.
@@ -12,7 +12,7 @@ pub fn validate_knowledge_entry(entry: &KnowledgeEntry) -> Result<(), Vec<String
         errors.push("oamp_version is required".into());
     } else if !is_supported_knowledge_version(&entry.oamp_version) {
         errors.push(format!(
-            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', got '{}'",
+            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', got '{}'",
             entry.oamp_version
         ));
     }
@@ -61,7 +61,7 @@ pub fn validate_knowledge_store(store: &KnowledgeStore) -> Result<(), Vec<String
         errors.push("oamp_version is required".into());
     } else if !is_supported_knowledge_version(&store.oamp_version) {
         errors.push(format!(
-            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', or '1.3.0', got '{}'",
+            "oamp_version must be one of '1.0.0', '1.1.0', '1.2.0', '1.3.0', or '1.3.1', got '{}'",
             store.oamp_version
         ));
     }

--- a/reference/rust/tests/roundtrip_test.rs
+++ b/reference/rust/tests/roundtrip_test.rs
@@ -52,6 +52,7 @@ fn test_governed_knowledge_entry_roundtrip() {
             retrieval: Some(GovernanceHandlingMode::Governed),
             export: Some(GovernanceHandlingMode::Governed),
             stream: None,
+            mediation: None,
         }),
     });
     entry.provenance = Some(Provenance {
@@ -60,6 +61,8 @@ fn test_governed_knowledge_entry_roundtrip() {
             timestamp: chrono::Utc::now(),
             agent_id: None,
             turn_id: Some("turn-1".to_string()),
+            task_id: None,
+            context_id: None,
         }],
         derived: Some(false),
     });
@@ -72,6 +75,58 @@ fn test_governed_knowledge_entry_roundtrip() {
         parsed.provenance.unwrap().sources[0].turn_id.as_deref(),
         Some("turn-1")
     );
+}
+
+#[test]
+fn test_v131_mediation_and_factory_provenance_roundtrip() {
+    let mut entry = KnowledgeEntry::new(
+        "user-1",
+        KnowledgeCategory::Fact,
+        "Factory cell learned a mediated deployment preference",
+        0.86,
+        "sess-cell-42",
+    );
+    entry.oamp_version = "1.3.1".to_string();
+    entry.governance = Some(Governance {
+        sensitivity_class: "confidential".to_string(),
+        labels: vec!["work.deployment".into()],
+        handling: Some(GovernanceHandling {
+            retrieval: Some(GovernanceHandlingMode::Governed),
+            export: Some(GovernanceHandlingMode::Governed),
+            stream: Some(GovernanceHandlingMode::Governed),
+            mediation: Some(GovernanceMediationMode::Required),
+        }),
+    });
+    entry.provenance = Some(Provenance {
+        sources: vec![ProvenanceSource {
+            session_id: "sess-cell-42".to_string(),
+            timestamp: chrono::Utc::now(),
+            agent_id: Some("cell-agent-42".to_string()),
+            turn_id: Some("turn-7".to_string()),
+            task_id: Some("task-7".to_string()),
+            context_id: Some("mission-3".to_string()),
+        }],
+        derived: Some(false),
+    });
+
+    let json = serde_json::to_string_pretty(&entry).unwrap();
+    assert!(json.contains("\"mediation\": \"required\""));
+    assert!(json.contains("\"task_id\": \"task-7\""));
+    assert!(json.contains("\"context_id\": \"mission-3\""));
+
+    let parsed: KnowledgeEntry = serde_json::from_str(&json).unwrap();
+    let handling = parsed
+        .governance
+        .as_ref()
+        .unwrap()
+        .handling
+        .as_ref()
+        .unwrap();
+    assert_eq!(handling.mediation, Some(GovernanceMediationMode::Required));
+    let source = &parsed.provenance.as_ref().unwrap().sources[0];
+    assert_eq!(source.task_id.as_deref(), Some("task-7"));
+    assert_eq!(source.context_id.as_deref(), Some("mission-3"));
+    assert!(validate::validate_knowledge_entry(&parsed).is_ok());
 }
 
 #[test]

--- a/reference/server/src/oamp_server/api/capabilities.py
+++ b/reference/server/src/oamp_server/api/capabilities.py
@@ -13,7 +13,7 @@ async def get_capabilities(request: Request) -> dict[str, object]:
     """Advertise optional OAMP capabilities supported by the reference backend."""
     settings = request.app.state.settings
     return {
-        "oamp_version": "1.3.0",
+        "oamp_version": "1.3.1",
         "capabilities": {
             "streaming": {
                 "supported": False,
@@ -30,7 +30,7 @@ async def get_capabilities(request: Request) -> dict[str, object]:
                 "withheld_stub_support": False,
                 "enforcement": {
                     "supported": settings.governance_enforcement_enabled,
-                    "spec_version": "1.3.0",
+                    "spec_version": "1.3.1",
                     "label_hierarchy": "dotted-prefix",
                     "reserved_top_level_labels": [
                         "identity",
@@ -48,6 +48,11 @@ async def get_capabilities(request: Request) -> dict[str, object]:
                     "existence_hiding": True,
                     "stream_filtering": False,
                     "export_full_supported": True,
+                    "mediation": {
+                        "supported": False,
+                        "trusted_issuers": [],
+                    },
+                    "provenance_query": ["task_id", "context_id"],
                 },
             },
             "user_id_format": {

--- a/reference/server/src/oamp_server/auth.py
+++ b/reference/server/src/oamp_server/auth.py
@@ -13,7 +13,7 @@ from .config import Settings
 
 
 class AgentGrantClaims(BaseModel):
-    """Portable v1.3 grant claims carried in JWT or OAMP-Grant headers."""
+    """Portable v1.3/v1.3.1 grant claims carried in JWT or OAMP-Grant headers."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -24,6 +24,10 @@ class AgentGrantClaims(BaseModel):
     oamp_write_labels: list[str] = Field(default_factory=list)
     oamp_sensitivity_max: Literal["public", "internal", "confidential", "restricted"]
     oamp_export_full: bool = False
+    iss: str | None = None
+    oamp_mediation_required: bool | None = None
+    oamp_task_id: str | None = None
+    oamp_context_id: str | None = None
     exp: int | None = None
 
 

--- a/reference/server/tests/test_capabilities.py
+++ b/reference/server/tests/test_capabilities.py
@@ -8,10 +8,13 @@ class TestCapabilities:
         resp = await client.get("/v1/capabilities")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["oamp_version"] == "1.3.0"
+        assert data["oamp_version"] == "1.3.1"
         governance = data["capabilities"]["governance"]
         assert governance["supported"] is True
         assert governance["extended_provenance_supported"] is True
         assert governance["withheld_stub_support"] is False
         assert governance["enforcement"]["supported"] is True
+        assert governance["enforcement"]["spec_version"] == "1.3.1"
         assert governance["enforcement"]["label_hierarchy"] == "dotted-prefix"
+        assert governance["enforcement"]["mediation"]["supported"] is False
+        assert governance["enforcement"]["provenance_query"] == ["task_id", "context_id"]

--- a/reference/typescript/src/__tests__/validation.test.ts
+++ b/reference/typescript/src/__tests__/validation.test.ts
@@ -59,6 +59,16 @@ describe('KnowledgeEntry validation', () => {
     expect(entry.oamp_version).toBe('1.3.0');
     expect(entry.governance?.labels).toContain('work.code');
   });
+
+  it('round-trips v1.3.1 mediation and factory provenance fields', () => {
+    const json = fs.readFileSync(path.join(__dirname, '../../../../validators/test-fixtures/valid/v1.3.1-knowledge-entry.json'), 'utf-8');
+    const entry = KnowledgeEntry.parse(JSON.parse(json));
+
+    expect(entry.oamp_version).toBe('1.3.1');
+    expect(entry.governance?.handling?.mediation).toBe('required');
+    expect(entry.provenance?.sources[0].task_id).toBe('task-7');
+    expect(entry.provenance?.sources[0].context_id).toBe('mission-3');
+  });
 });
 
 describe('UserModel validation', () => {

--- a/reference/typescript/src/knowledge.ts
+++ b/reference/typescript/src/knowledge.ts
@@ -14,6 +14,8 @@ export const ProvenanceSource = z.object({
   agent_id: z.string().optional(),
   timestamp: z.string().datetime(),
   turn_id: z.string().optional(),
+  task_id: z.string().optional(),
+  context_id: z.string().optional(),
 });
 export type ProvenanceSource = z.infer<typeof ProvenanceSource>;
 
@@ -27,6 +29,7 @@ export const GovernanceHandling = z.object({
   retrieval: z.enum(['governed', 'ungoverned']).optional(),
   export: z.enum(['governed', 'ungoverned']).optional(),
   stream: z.enum(['governed', 'ungoverned']).optional(),
+  mediation: z.enum(['required', 'optional']).optional(),
 });
 export type GovernanceHandling = z.infer<typeof GovernanceHandling>;
 
@@ -43,7 +46,7 @@ export const KnowledgeDecay = z.object({
 });
 
 export const KnowledgeEntry = z.object({
-  oamp_version: z.enum(['1.0.0', '1.1.0', '1.2.0', '1.3.0']),
+  oamp_version: z.enum(['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.3.1']),
   type: z.literal('knowledge_entry'),
   id: z.string().uuid(),
   user_id: z.string().min(1),
@@ -60,7 +63,7 @@ export const KnowledgeEntry = z.object({
 export type KnowledgeEntry = z.infer<typeof KnowledgeEntry>;
 
 export const KnowledgeStore = z.object({
-  oamp_version: z.enum(['1.0.0', '1.1.0', '1.2.0', '1.3.0']),
+  oamp_version: z.enum(['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.3.1']),
   type: z.literal('knowledge_store'),
   user_id: z.string().min(1),
   entries: z.array(KnowledgeEntry),

--- a/spec/v1.3/examples/agent-grant-claims.json
+++ b/spec/v1.3/examples/agent-grant-claims.json
@@ -1,4 +1,5 @@
 {
+  "iss": "governor",
   "sub": "user-123",
   "oamp_agent_id": "coding-assistant-v9",
   "oamp_grant_id": "grant-2026-05-07-001",
@@ -12,5 +13,8 @@
   ],
   "oamp_sensitivity_max": "internal",
   "oamp_export_full": false,
+  "oamp_mediation_required": true,
+  "oamp_task_id": "task-7",
+  "oamp_context_id": "mission-3",
   "exp": 1746662400
 }

--- a/spec/v1.3/examples/capabilities-enforcement.json
+++ b/spec/v1.3/examples/capabilities-enforcement.json
@@ -1,5 +1,5 @@
 {
-  "oamp_version": "1.3.0",
+  "oamp_version": "1.3.1",
   "capabilities": {
     "streaming": {
       "supported": true,
@@ -26,7 +26,7 @@
       "withheld_stub_support": false,
       "enforcement": {
         "supported": true,
-        "spec_version": "1.3.0",
+        "spec_version": "1.3.1",
         "label_hierarchy": "dotted-prefix",
         "reserved_top_level_labels": [
           "identity",
@@ -46,7 +46,17 @@
         ],
         "existence_hiding": true,
         "stream_filtering": true,
-        "export_full_supported": true
+        "export_full_supported": true,
+        "mediation": {
+          "supported": true,
+          "trusted_issuers": [
+            "governor"
+          ]
+        },
+        "provenance_query": [
+          "task_id",
+          "context_id"
+        ]
       }
     },
     "user_id_format": {

--- a/spec/v1.3/knowledge-entry.schema.json
+++ b/spec/v1.3/knowledge-entry.schema.json
@@ -8,8 +8,8 @@
   "properties": {
     "oamp_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"],
-      "description": "OAMP spec version. Use '1.2.0' or '1.3.0' when governed-memory fields are present."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"],
+      "description": "OAMP spec version. Use '1.2.0', '1.3.0', or '1.3.1' when governed-memory fields are present."
     },
     "type": {
       "type": "string",
@@ -117,6 +117,11 @@
             "stream": {
               "type": "string",
               "enum": ["governed", "ungoverned"]
+            },
+            "mediation": {
+              "type": "string",
+              "enum": ["required", "optional"],
+              "description": "Whether this entry requires access through a trusted mediation issuer."
             }
           },
           "additionalProperties": false
@@ -172,6 +177,12 @@
           "type": "string"
         },
         "turn_id": {
+          "type": "string"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "context_id": {
           "type": "string"
         }
       },

--- a/spec/v1.3/knowledge-store.schema.json
+++ b/spec/v1.3/knowledge-store.schema.json
@@ -8,8 +8,8 @@
   "properties": {
     "oamp_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"],
-      "description": "OAMP spec version. Use '1.2.0' or '1.3.0' when any entry exercises governed-memory fields."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"],
+      "description": "OAMP spec version. Use '1.2.0', '1.3.0', or '1.3.1' when any entry exercises governed-memory fields."
     },
     "type": {
       "type": "string",
@@ -58,7 +58,7 @@
       "properties": {
         "oamp_version": {
           "type": "string",
-          "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]
+          "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.3.1"]
         },
         "type": {
           "type": "string",
@@ -150,6 +150,10 @@
                 "stream": {
                   "type": "string",
                   "enum": ["governed", "ungoverned"]
+                },
+                "mediation": {
+                  "type": "string",
+                  "enum": ["required", "optional"]
                 }
               },
               "additionalProperties": false
@@ -200,6 +204,12 @@
           "type": "string"
         },
         "turn_id": {
+          "type": "string"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "context_id": {
           "type": "string"
         }
       },

--- a/spec/v1.3/oamp-v1.3-draft.md
+++ b/spec/v1.3/oamp-v1.3-draft.md
@@ -154,9 +154,14 @@ The v1.2 `handling` hints become load-bearing in v1.3:
 - `export: "ungoverned"` exempts the entry from export-path filtering
 - `stream: "governed"` means v1.1 streaming paths MUST apply grant filtering
 - `stream: "ungoverned"` exempts the entry from stream filtering
+- `mediation: "required"` means access to the entry requires a valid grant from
+  a trusted mediation issuer
+- `mediation: "optional"` means no mediation constraint is expressed
 
 When `governance` is present and a handling value is omitted, the effective
 default is `governed` for that surface.
+
+When `mediation` is omitted, the effective default is `optional`.
 
 ---
 
@@ -168,6 +173,7 @@ When bearer authentication uses JWT, the token carries these additional claims:
 
 ```json
 {
+  "iss": "governor",
   "sub": "user-abc",
   "oamp_agent_id": "medical-assistant-v3",
   "oamp_grant_id": "grant-2026-05-07-001",
@@ -175,6 +181,9 @@ When bearer authentication uses JWT, the token carries these additional claims:
   "oamp_write_labels": ["health", "preferences"],
   "oamp_sensitivity_max": "restricted",
   "oamp_export_full": false,
+  "oamp_mediation_required": true,
+  "oamp_task_id": "task-7",
+  "oamp_context_id": "mission-3",
   "exp": 1746662400
 }
 ```
@@ -187,6 +196,10 @@ When bearer authentication uses JWT, the token carries these additional claims:
 | `oamp_write_labels` | MUST | Labels the agent may write |
 | `oamp_sensitivity_max` | MUST | Highest readable/writable sensitivity class |
 | `oamp_export_full` | MAY | Whether full unfiltered export is authorized |
+| `iss` | MUST for mediation-required resources; otherwise MAY | Stable identifier of the authority that minted the grant |
+| `oamp_mediation_required` | MAY | Signals that this grant is intended for a mediated flow |
+| `oamp_task_id` | MAY | Identifier of the unit of work the agent was provisioned to perform |
+| `oamp_context_id` | MAY | Opaque grouping identifier above the task |
 
 Empty `oamp_read_labels` means read-nothing.
 
@@ -204,6 +217,12 @@ When a write happens under a v1.3 grant, the backend MUST verify:
 
 For entries with `provenance.sources[*].agent_id`, backends SHOULD validate each
 listed `agent_id` against the calling grant or their local trust model.
+
+When a write happens under a v1.3.1 grant carrying `oamp_task_id` or
+`oamp_context_id`, the backend SHOULD stamp those values onto
+`provenance.sources[*].task_id` and `provenance.sources[*].context_id` for the
+source produced by that grant. These fields are descriptive attribution only and
+MUST NOT widen access.
 
 ---
 
@@ -270,7 +289,7 @@ v1.3 extends the v1.2 governance capabilities block:
 
 ```json
 {
-  "oamp_version": "1.3.0",
+  "oamp_version": "1.3.1",
   "capabilities": {
     "governance": {
       "supported": true,
@@ -280,7 +299,7 @@ v1.3 extends the v1.2 governance capabilities block:
       "withheld_stub_support": false,
       "enforcement": {
         "supported": true,
-        "spec_version": "1.3.0",
+        "spec_version": "1.3.1",
         "label_hierarchy": "dotted-prefix",
         "reserved_top_level_labels": [
           "identity", "location", "health", "finance",
@@ -290,7 +309,12 @@ v1.3 extends the v1.2 governance capabilities block:
         "grant_transport": ["jwt-claims", "oamp-grant-header"],
         "existence_hiding": true,
         "stream_filtering": true,
-        "export_full_supported": true
+        "export_full_supported": true,
+        "mediation": {
+          "supported": true,
+          "trusted_issuers": ["governor"]
+        },
+        "provenance_query": ["task_id", "context_id"]
       }
     }
   }
@@ -307,6 +331,8 @@ v1.3 extends the v1.2 governance capabilities block:
 | `enforcement.existence_hiding` | boolean | MUST | Whether out-of-scope ids are hidden as 404 |
 | `enforcement.stream_filtering` | boolean | MUST | Whether v1.1 streams are filtered |
 | `enforcement.export_full_supported` | boolean | MUST | Whether full export claims are honored |
+| `enforcement.mediation` | object | MAY | Mediation support and trusted issuer identifiers |
+| `enforcement.provenance_query` | array of string | MAY | Supported provenance-context filters (`task_id`, `context_id`) |
 
 ---
 

--- a/spec/v1.3/openapi.yaml
+++ b/spec/v1.3/openapi.yaml
@@ -8,7 +8,7 @@ info:
 
     Endpoints and response shapes not repeated here inherit their definitions
     from `spec/v1/openapi.yaml`.
-  version: "1.3.0-draft"
+  version: "1.3.1-draft"
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
@@ -162,7 +162,7 @@ components:
       properties:
         oamp_version:
           type: string
-          enum: ["1.1.0", "1.2.0", "1.3.0"]
+          enum: ["1.1.0", "1.2.0", "1.3.0", "1.3.1"]
           description: Highest OAMP minor version advertised by the backend.
         capabilities:
           $ref: '#/components/schemas/Capabilities'
@@ -268,7 +268,7 @@ components:
           type: boolean
         spec_version:
           type: string
-          enum: ["1.3.0"]
+          enum: ["1.3.0", "1.3.1"]
         label_hierarchy:
           type: string
           enum: ["dotted-prefix"]
@@ -287,6 +287,27 @@ components:
           type: boolean
         export_full_supported:
           type: boolean
+        mediation:
+          $ref: '#/components/schemas/MediationCapabilities'
+        provenance_query:
+          type: array
+          items:
+            type: string
+            enum: ["task_id", "context_id"]
+          description: Optional provenance-context filters supported by the backend.
+      additionalProperties: false
+
+    MediationCapabilities:
+      type: object
+      required: [supported]
+      properties:
+        supported:
+          type: boolean
+        trusted_issuers:
+          type: array
+          items:
+            type: string
+          description: Trusted issuer identifiers only; key material is never advertised.
       additionalProperties: false
 
     UserIdFormat:

--- a/validators/test-fixtures/valid/quote'path-knowledge-entry.json
+++ b/validators/test-fixtures/valid/quote'path-knowledge-entry.json
@@ -1,0 +1,13 @@
+{
+  "oamp_version": "1.3.1",
+  "type": "knowledge_entry",
+  "id": "6e3e7b4e-6e74-4d98-8548-31e5e5b94457",
+  "user_id": "user-quoted-path",
+  "category": "fact",
+  "content": "Validator paths are passed as data, not interpolated into Python source.",
+  "confidence": 1.0,
+  "source": {
+    "session_id": "sess-quoted-path",
+    "timestamp": "2026-05-31T12:00:00Z"
+  }
+}

--- a/validators/test-fixtures/valid/v1.3.1-knowledge-entry.json
+++ b/validators/test-fixtures/valid/v1.3.1-knowledge-entry.json
@@ -1,0 +1,39 @@
+{
+  "oamp_version": "1.3.1",
+  "type": "knowledge_entry",
+  "id": "8f6ec84e-17f5-4dc2-a8c3-f056d3124925",
+  "user_id": "user-123",
+  "category": "fact",
+  "content": "Factory cell learned a mediated deployment preference.",
+  "confidence": 0.86,
+  "source": {
+    "session_id": "sess-cell-42",
+    "agent_id": "cell-agent-42",
+    "timestamp": "2026-05-31T12:00:00Z"
+  },
+  "provenance": {
+    "sources": [
+      {
+        "session_id": "sess-cell-42",
+        "timestamp": "2026-05-31T12:00:00Z",
+        "agent_id": "cell-agent-42",
+        "turn_id": "turn-7",
+        "task_id": "task-7",
+        "context_id": "mission-3"
+      }
+    ],
+    "derived": false
+  },
+  "governance": {
+    "sensitivity_class": "confidential",
+    "labels": [
+      "work.deployment"
+    ],
+    "handling": {
+      "retrieval": "governed",
+      "export": "governed",
+      "stream": "governed",
+      "mediation": "required"
+    }
+  }
+}

--- a/validators/validate.sh
+++ b/validators/validate.sh
@@ -16,7 +16,14 @@ if [ ! -f "$DOC" ]; then
     exit 1
 fi
 
-VERSION=$(python3 -c "import json; print(json.load(open('$DOC')).get('oamp_version', '1.0.0'))" 2>/dev/null || echo "1.0.0")
+VERSION=$(python3 - "$DOC" <<'PY' 2>/dev/null || echo "1.0.0"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as doc_file:
+    print(json.load(doc_file).get("oamp_version", "1.0.0"))
+PY
+)
 
 case "$VERSION" in
     1.3.0|1.3.1) SPEC_DIR="$SCRIPT_DIR/../spec/v1.3" ;;
@@ -26,7 +33,14 @@ esac
 
 # Auto-detect schema from "type" field
 if [ -z "$2" ]; then
-    TYPE=$(python3 -c "import json; print(json.load(open('$DOC'))['type'])" 2>/dev/null || echo "")
+    TYPE=$(python3 - "$DOC" <<'PY' 2>/dev/null || echo ""
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as doc_file:
+    print(json.load(doc_file)["type"])
+PY
+)
     case "$TYPE" in
         knowledge_entry) SCHEMA="knowledge-entry" ;;
         knowledge_store) SCHEMA="knowledge-store" ;;
@@ -47,22 +61,25 @@ fi
 if command -v ajv &>/dev/null; then
     ajv validate -s "$SCHEMA_FILE" -d "$DOC" --spec=draft2020
 elif command -v python3 &>/dev/null; then
-    python3 -c "
-import json, sys
+    python3 - "$SCHEMA_FILE" "$DOC" "$SCHEMA" <<'PY'
+import json
+import sys
+
+schema_file, doc_file, schema_name = sys.argv[1:]
 try:
     from jsonschema import validate, Draft202012Validator
-    with open('$SCHEMA_FILE') as sf, open('$DOC') as df:
+    with open(schema_file, encoding="utf-8") as sf, open(doc_file, encoding="utf-8") as df:
         schema = json.load(sf)
         doc = json.load(df)
         Draft202012Validator(schema).validate(doc)
-        print('Valid: $DOC matches $SCHEMA schema')
+        print(f"Valid: {doc_file} matches {schema_name} schema")
 except ImportError:
     print('Warning: jsonschema not installed. Install: pip install jsonschema')
     sys.exit(1)
 except Exception as e:
     print(f'Invalid: {e}')
     sys.exit(1)
-"
+PY
 else
     echo "Error: Neither ajv nor python3 available"
     exit 1

--- a/validators/validate.sh
+++ b/validators/validate.sh
@@ -19,7 +19,7 @@ fi
 VERSION=$(python3 -c "import json; print(json.load(open('$DOC')).get('oamp_version', '1.0.0'))" 2>/dev/null || echo "1.0.0")
 
 case "$VERSION" in
-    1.3.0) SPEC_DIR="$SCRIPT_DIR/../spec/v1.3" ;;
+    1.3.0|1.3.1) SPEC_DIR="$SCRIPT_DIR/../spec/v1.3" ;;
     1.2.0) SPEC_DIR="$SCRIPT_DIR/../spec/v1.2" ;;
     *) SPEC_DIR="$SCRIPT_DIR/../spec/v1" ;;
 esac


### PR DESCRIPTION
## Summary

- Adds OAMP v1.3.1 schema support for `handling.mediation` and provenance `task_id` / `context_id` while preserving v1.3 compatibility.
- Extends grant claim documentation/examples and the reference server claim model with `iss`, `oamp_mediation_required`, `oamp_task_id`, and `oamp_context_id`.
- Advertises `enforcement.mediation` and `enforcement.provenance_query` in OpenAPI, examples, and reference server capabilities.
- Adds optional mediation/provenance context fields and round-trip coverage across Rust, TypeScript, Python, Go, and Elixir reference types.

## Validation

- `mise exec -- cargo test` in `reference/rust`
- `mise exec -- go test ./...` in `reference/go`
- `mise exec -- npm test` in `reference/typescript`
- `mise exec -- env PYTHONPATH=src python -m pytest tests/test_oamp_types.py` in `reference/python`
- `mise exec -- mix test` in `reference/elixir`
- `mise exec -- python -m pytest tests` in `reference/server`
- `for doc in validators/test-fixtures/valid/*.json; do ./validators/validate.sh "$doc"; done`
