### PR TITLE
fix: harden CI runner lanes

### DIFF
--- a/.github/workflows/auto-translate-spec.yml
+++ b/.github/workflows/auto-translate-spec.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0  # auto-translate.py reads git log timestamps
 
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,14 @@ jobs:
 
   test-rust:
     name: Rust
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Cache Rust artifacts
         uses: actions/cache@v5
@@ -45,12 +47,14 @@ jobs:
 
   test-typescript:
     name: TypeScript
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -78,7 +82,7 @@ jobs:
 
   test-python:
     name: Python ${{ matrix.python-version }}
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     strategy:
@@ -89,6 +93,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} via mise
         uses: jdx/mise-action@v4
@@ -119,12 +125,14 @@ jobs:
 
   test-go:
     name: Go
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -150,12 +158,14 @@ jobs:
 
   test-elixir:
     name: Elixir
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -186,12 +196,14 @@ jobs:
 
   test-server:
     name: Reference Server
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -224,13 +236,15 @@ jobs:
 
   interop-canary:
     name: Interop canary (reference server self-loopback)
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     needs: [test-server]
     timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -306,7 +320,7 @@ jobs:
 
   cross-language-check:
     name: Cross-language consistency
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     # Only require what reliably runs on this runner today. The TS/Go/Elixir/
     # Python-matrix jobs fail on toolchain or setup-python issues that need
     # runner-side fixes; including them here would skip this check on every
@@ -318,6 +332,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   droid-review:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, droid-agent]
     permissions:
       contents: write
       pull-requests: write
@@ -22,9 +22,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
       (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, droid-agent]
     permissions:
       contents: read
       pull-requests: write
@@ -31,8 +31,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,13 @@ env:
 jobs:
   test:
     name: Run tests before release
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -72,10 +74,12 @@ jobs:
   publish-rust:
     name: Publish Rust crate
     needs: test
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -89,10 +93,12 @@ jobs:
   publish-npm:
     name: Publish npm package
     needs: test
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -114,10 +120,12 @@ jobs:
   publish-pypi:
     name: Publish Python package
     needs: test
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -142,10 +150,12 @@ jobs:
   publish-elixir:
     name: Publish Elixir package
     needs: test
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4
@@ -161,10 +171,12 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     needs: test
-    runs-on: [self-hosted, Linux, X64, kizuna-stage-1]
+    runs-on: [self-hosted, Linux, X64, voxeltron-ci]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up toolchains via mise
         uses: jdx/mise-action@v4


### PR DESCRIPTION
## Summary
- route generic self-hosted CI/release jobs away from host-specific labels and onto capability labels
- run Droid/Factory workflows on the droid-agent lane
- set actions/checkout persist-credentials: false for credential hygiene
- pin Factory Droid action to the reviewed SHA where it was using main

## Verification
- Parsed all .github/workflows/*.yml with Ruby YAML loader
- Ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by restricting credential persistence during automated workflows.
  * Updated build infrastructure to use optimized self-hosted runners, improving pipeline reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->